### PR TITLE
Update develop branch defaults

### DIFF
--- a/sdk/bare/.cproject
+++ b/sdk/bare/.cproject
@@ -30,9 +30,7 @@
 								</option>
 								<option id="xilinx.gnu.compiler.inferred.swplatform.flags.390797143" name="Software Platform Inferred Flags" superClass="xilinx.gnu.compiler.inferred.swplatform.flags" value="  " valueType="string"/>
 								<option id="xilinx.gnu.compiler.misc.other.1858768302" name="Other flags" superClass="xilinx.gnu.compiler.misc.other" value="-c -fmessage-length=0 -MT&quot;$@&quot; -mcpu=cortex-a9 -mfpu=vfpv3 -mfloat-abi=hard" valueType="string"/>
-								<option id="xilinx.gnu.compiler.symbols.defined.1897050119" name="Defined symbols (-D)" superClass="xilinx.gnu.compiler.symbols.defined" valueType="definedSymbols">
-									<listOptionValue builtIn="false" value="APP_PARAMS"/>
-								</option>
+								<option id="xilinx.gnu.compiler.symbols.defined.1897050119" name="Defined symbols (-D)" superClass="xilinx.gnu.compiler.symbols.defined" valueType="definedSymbols"/>
 								<inputType id="xilinx.gnu.armv7.c.compiler.input.1322043513" name="C source files" superClass="xilinx.gnu.armv7.c.compiler.input"/>
 							</tool>
 							<tool id="xilinx.gnu.armv7.cxx.toolchain.compiler.debug.418875667" name="ARM v7 g++ compiler" superClass="xilinx.gnu.armv7.cxx.toolchain.compiler.debug">

--- a/sdk/bare/sys/scheduler.h
+++ b/sdk/bare/sys/scheduler.h
@@ -8,11 +8,13 @@
 
 // SysTick
 //
-// The basic time quantum is defined to be SYS_TICK_FREQ (10kHz)
-// At 666.6 MHz DSP clock, we have 66.6k cycles per time slice,
-// meaning all tasks combined have to consume <= 66.6k cycles
+// The basic time quantum is defined to be SYS_TICK_FREQ.
 //
-#define SYS_TICK_FREQ	(40000) // Hz
+// As an example, say we set this to 10kHz. At 666.6 MHz DSP clock,
+// we will have 66.6k cycles per time slice, meaning all tasks
+// combined have to consume <= 66.6k cycles
+//
+#define SYS_TICK_FREQ	(10000) // Hz
 #define SYS_TICK_USEC	(SEC_TO_USEC(1) / SYS_TICK_FREQ)
 
 //


### PR DESCRIPTION
This PR updates the `develop` branch to:
- default to 10kHz scheduler (it was 40kHz which is too fast for many applications)
- removes enabled applications (when people checkout `develop`, it should not come with enabled applications by default...)