### PR TITLE
Add constant for DQ transforms to function calls

### DIFF
--- a/sdk/bare/sys/transform.c
+++ b/sdk/bare/sys/transform.c
@@ -2,11 +2,11 @@
 #include "defines.h"
 #include <math.h>
 
-void transform_clarke(double *abc, double *xyz)
+void transform_clarke(double C, double *abc, double *xyz)
 {
-	xyz[0] = SQRT23 * (1		*abc[0]			-0.5	*abc[1]			-0.5	*abc[2]);
-	xyz[1] = SQRT23 * (0		*abc[0]		+SQRT3/2	*abc[1]		-SQRT3/2	*abc[2]);
-	xyz[2] = SQRT23 * (1/SQRT2	*abc[0]		+1/SQRT2	*abc[1]		+1/SQRT2	*abc[2]);
+	xyz[0] = C * (1		*abc[0]			-0.5	*abc[1]			-0.5	*abc[2]);
+	xyz[1] = C * (0		*abc[0]		+SQRT3/2	*abc[1]		-SQRT3/2	*abc[2]);
+	xyz[2] = C * (1/SQRT2	*abc[0]		+1/SQRT2	*abc[1]		+1/SQRT2	*abc[2]);
 }
 
 void transform_park(double theta, double *xyz, double *dqz)
@@ -16,16 +16,16 @@ void transform_park(double theta, double *xyz, double *dqz)
 	dqz[2] = +0				*xyz[0]		+0			*xyz[1]		+1	*xyz[2];
 }
 
-void transform_dqz(double theta, double *abc, double *dqz)
+void transform_dqz(double C, double theta, double *abc, double *dqz)
 {
 	double xyz[3];
-	transform_clarke(abc, xyz);
+	transform_clarke(C, abc, xyz);
 	transform_park(theta, xyz, dqz);
 }
 
-void transform_dqz_inverse(double theta, double *abc, double *dqz)
+void transform_dqz_inverse(double C, double theta, double *abc, double *dqz)
 {
-	abc[0] = SQRT23 * (cos(theta)			*dqz[0] 	-sin(theta)			*dqz[1] 	+(SQRT2/2)	*dqz[2]);
-	abc[1] = SQRT23 * (cos(theta - PI23)	*dqz[0] 	-sin(theta - PI23)	*dqz[1] 	+(SQRT2/2)	*dqz[2]);
-	abc[2] = SQRT23 * (cos(theta + PI23)	*dqz[0] 	-sin(theta + PI23)	*dqz[1] 	+(SQRT2/2)	*dqz[2]);
+	abc[0] = C * (cos(theta)			*dqz[0] 	-sin(theta)			*dqz[1] 	+(SQRT2/2)	*dqz[2]);
+	abc[1] = C * (cos(theta - PI23)	*dqz[0] 	-sin(theta - PI23)	*dqz[1] 	+(SQRT2/2)	*dqz[2]);
+	abc[2] = C * (cos(theta + PI23)	*dqz[0] 	-sin(theta + PI23)	*dqz[1] 	+(SQRT2/2)	*dqz[2]);
 }

--- a/sdk/bare/sys/transform.h
+++ b/sdk/bare/sys/transform.h
@@ -1,10 +1,13 @@
 #ifndef TRANSFORM_H
 #define TRANSFORM_H
 
-void transform_dqz(double theta, double *abc, double *dqz);
-void transform_dqz_inverse(double theta, double *abc, double *dqz);
+#define TRANS_DQZ_C_INVARIANT_POWER			(0.816496580927726032732) // sqrt(2/3)
+#define TRANS_DQZ_C_INVARIANT_AMPLITUDE		(0.666666666666666666667) // 2/3
 
-void transform_clarke(double *abc, double *xyz);
+void transform_dqz(double C, double theta, double *abc, double *dqz);
+void transform_dqz_inverse(double C, double theta, double *abc, double *dqz);
+
+void transform_clarke(double C, double *abc, double *xyz);
 void transform_park(double theta, double *xyz, double *dqz);
 
 #endif // TRANSFORM_H


### PR DESCRIPTION
This PR adds the ability for each user to specify if they would like to do the power invariant or amplitude invariant DQ transform via the `C` function argument.