### PR TITLE
Update command handler signatures

### DIFF
--- a/sdk/bare/sys/cmd/cmd_help.c
+++ b/sdk/bare/sys/cmd/cmd_help.c
@@ -21,7 +21,7 @@ void cmd_help_register(void)
 //
 // Handles the 'help' command
 //
-int cmd_help(char **argv, int argc)
+int cmd_help(int argc, char **argv)
 {
 	if (argc > 1) {
 		return INVALID_ARGUMENTS;

--- a/sdk/bare/sys/cmd/cmd_help.h
+++ b/sdk/bare/sys/cmd/cmd_help.h
@@ -3,6 +3,6 @@
 
 void cmd_help_register(void);
 
-int cmd_help(char **argv, int argc);
+int cmd_help(int argc, char **argv);
 
 #endif // CMD_HELP_H

--- a/sdk/bare/sys/cmd/cmd_hw.c
+++ b/sdk/bare/sys/cmd/cmd_hw.c
@@ -38,7 +38,7 @@ void cmd_hw_register(void)
 // Handles the 'hw' command
 // and all sub-commands
 //
-int cmd_hw(char **argv, int argc)
+int cmd_hw(int argc, char **argv)
 {
 	// Handle 'pwm' sub-command
 	if (strcmp("pwm", argv[1]) == 0) {

--- a/sdk/bare/sys/cmd/cmd_hw.h
+++ b/sdk/bare/sys/cmd/cmd_hw.h
@@ -3,6 +3,6 @@
 
 void cmd_hw_register(void);
 
-int cmd_hw(char **argv, int argc);
+int cmd_hw(int argc, char **argv);
 
 #endif // CMD_HW_H

--- a/sdk/bare/sys/cmd/cmd_log.c
+++ b/sdk/bare/sys/cmd/cmd_log.c
@@ -34,7 +34,7 @@ void cmd_log_register(void)
 // Handles the 'log' command
 // and all sub-commands
 //
-int cmd_log(char **argv, int argc)
+int cmd_log(int argc, char **argv)
 {
 	// Handle 'reg' sub-command
 	if (strcmp("reg", argv[1]) == 0) {

--- a/sdk/bare/sys/cmd/cmd_log.h
+++ b/sdk/bare/sys/cmd/cmd_log.h
@@ -3,6 +3,6 @@
 
 void cmd_log_register(void);
 
-int cmd_log(char **argv, int argc);
+int cmd_log(int argc, char **argv);
 
 #endif // CMD_LOG_H

--- a/sdk/bare/sys/commands.c
+++ b/sdk/bare/sys/commands.c
@@ -44,7 +44,7 @@ static pending_cmd_t pending_cmds[MAX_PENDING_CMDS] = {0};
 static int pending_cmd_write_idx = 0;
 static int pending_cmd_read_idx = 0;
 
-static int _command_handler(char **argv, int argc);
+static int _command_handler(int argc, char **argv);
 
 // Head of linked list of commands
 command_entry_t *cmds = NULL;
@@ -212,7 +212,7 @@ void commands_callback_exec(void *arg)
 		// Don't run a cmd that has errors
 		err = p->err;
 		if (err == SUCCESS) {
-			err = _command_handler(p->argv, p->argc);
+			err = _command_handler(p->argc, p->argv);
 		}
 
 		// Display command status to user
@@ -258,7 +258,7 @@ void commands_callback_exec(void *arg)
 void commands_cmd_init(command_entry_t *cmd_entry,
 		const char *cmd, const char *desc,
 		command_help_t *help, int num_help_cmds,
-		int (*cmd_function)(char**, int)
+		int (*cmd_function)(int, char**)
 )
 {
 	cmd_entry->cmd = cmd;
@@ -295,17 +295,17 @@ void commands_start_msg(void)
 
 // _command_handler
 //
-// Takes `argv` and `argc` and finds
+// Takes `argc` and `argv` and finds
 // the command function to call.
 //
-int _command_handler(char **argv, int argc)
+int _command_handler(int argc, char **argv)
 {
 	command_entry_t *c = cmds;
 
 	while (c != NULL) {
 		if (strcmp(argv[0], c->cmd) == 0) {
 			// Found command to run!
-			return c->cmd_function(argv, argc);
+			return c->cmd_function(argc, argv);
 		}
 
 		c = c->next;

--- a/sdk/bare/sys/commands.h
+++ b/sdk/bare/sys/commands.h
@@ -15,7 +15,7 @@ typedef struct command_entry_t {
 	const char *desc;
 	command_help_t *help;
 	int num_help_cmds;
-	int (*cmd_function)(char**, int);
+	int (*cmd_function)(int, char**);
 
 	// Pointer to next cmd; set this to NULL in user code.
 	// When cmd is registered, this will form a linked list.
@@ -34,7 +34,7 @@ void commands_callback_exec(void *arg);
 void commands_cmd_init(command_entry_t *cmd_entry,
 		const char *cmd, const char *desc,
 		command_help_t *help, int num_help_cmds,
-		int (*cmd_function)(char**, int)
+		int (*cmd_function)(int, char**)
 );
 void commands_cmd_register(command_entry_t *cmd_entry);
 

--- a/sdk/bare/usr/deadtime_comp/cmd/cmd_dtc.c
+++ b/sdk/bare/usr/deadtime_comp/cmd/cmd_dtc.c
@@ -34,7 +34,7 @@ void cmd_dtc_register(void)
 // Handles the 'dtc' command
 // and all sub-commands
 //
-int cmd_dtc(char **argv, int argc)
+int cmd_dtc(int argc, char **argv)
 {
 	// Handle 'init' sub-command
 	if (strcmp("init", argv[1]) == 0) {

--- a/sdk/bare/usr/deadtime_comp/cmd/cmd_dtc.h
+++ b/sdk/bare/usr/deadtime_comp/cmd/cmd_dtc.h
@@ -3,6 +3,6 @@
 
 void cmd_dtc_register(void);
 
-int cmd_dtc(char **argv, int argc);
+int cmd_dtc(int argc, char **argv);
 
 #endif // CMD_DTC_H

--- a/sdk/bare/usr/deadtime_comp/cmd/cmd_inv.c
+++ b/sdk/bare/usr/deadtime_comp/cmd/cmd_inv.c
@@ -32,7 +32,7 @@ void cmd_inv_register(void)
 // Handles the 'inv' command
 // and all sub-commands
 //
-int cmd_inv(char **argv, int argc)
+int cmd_inv(int argc, char **argv)
 {
 	// Handle 'dtc' sub-command
 	if (strcmp("dtc", argv[1]) == 0) {

--- a/sdk/bare/usr/deadtime_comp/cmd/cmd_inv.h
+++ b/sdk/bare/usr/deadtime_comp/cmd/cmd_inv.h
@@ -3,6 +3,6 @@
 
 void cmd_inv_register(void);
 
-int cmd_inv(char **argv, int argc);
+int cmd_inv(int argc, char **argv);
 
 #endif // CMD_INV_H

--- a/sdk/bare/usr/params/cmd/cmd_cc.c
+++ b/sdk/bare/usr/params/cmd/cmd_cc.c
@@ -39,7 +39,7 @@ void cmd_cc_register(void)
 // Handles the 'cc' command
 // and all sub-commands
 //
-int cmd_cc(char **argv, int argc)
+int cmd_cc(int argc, char **argv)
 {
 	// Handle 'init' sub-command
 	if (strcmp("init", argv[1]) == 0) {

--- a/sdk/bare/usr/params/cmd/cmd_cc.h
+++ b/sdk/bare/usr/params/cmd/cmd_cc.h
@@ -3,6 +3,6 @@
 
 void cmd_cc_register(void);
 
-int cmd_cc(char **argv, int argc);
+int cmd_cc(int argc, char **argv);
 
 #endif // CMD_CC_H

--- a/sdk/bare/usr/params/cmd/cmd_inv.c
+++ b/sdk/bare/usr/params/cmd/cmd_inv.c
@@ -33,7 +33,7 @@ void cmd_inv_register(void)
 // Handles the 'inv' command
 // and all sub-commands
 //
-int cmd_inv(char **argv, int argc)
+int cmd_inv(int argc, char **argv)
 {
 	// Handle 'dtc' sub-command
 	if (strcmp("dtc", argv[1]) == 0) {

--- a/sdk/bare/usr/params/cmd/cmd_inv.h
+++ b/sdk/bare/usr/params/cmd/cmd_inv.h
@@ -3,6 +3,6 @@
 
 void cmd_inv_register(void);
 
-int cmd_inv(char **argv, int argc);
+int cmd_inv(int argc, char **argv);
 
 #endif // CMD_INV_H

--- a/sdk/bare/usr/pmsm_mc/cmd/cmd_cc.c
+++ b/sdk/bare/usr/pmsm_mc/cmd/cmd_cc.c
@@ -36,7 +36,7 @@ void cmd_cc_register(void)
 // Handles the 'cc' command
 // and all sub-commands
 //
-int cmd_cc(char **argv, int argc)
+int cmd_cc(int argc, char **argv)
 {
 	// Handle 'init' sub-command
 	if (strcmp("init", argv[1]) == 0) {

--- a/sdk/bare/usr/pmsm_mc/cmd/cmd_cc.h
+++ b/sdk/bare/usr/pmsm_mc/cmd/cmd_cc.h
@@ -3,6 +3,6 @@
 
 void cmd_cc_register(void);
 
-int cmd_cc(char **argv, int argc);
+int cmd_cc(int argc, char **argv);
 
 #endif // CMD_CC_H

--- a/sdk/bare/usr/pmsm_mc/cmd/cmd_mc.c
+++ b/sdk/bare/usr/pmsm_mc/cmd/cmd_mc.c
@@ -35,7 +35,7 @@ void cmd_mc_register(void)
 // Handles the 'mc' command
 // and all sub-commands
 //
-int cmd_mc(char **argv, int argc)
+int cmd_mc(int argc, char **argv)
 {
 	// Handle 'init' sub-command
 	if (strcmp("init", argv[1]) == 0) {

--- a/sdk/bare/usr/pmsm_mc/cmd/cmd_mc.h
+++ b/sdk/bare/usr/pmsm_mc/cmd/cmd_mc.h
@@ -3,6 +3,6 @@
 
 void cmd_mc_register(void);
 
-int cmd_mc(char **argv, int argc);
+int cmd_mc(int argc, char **argv);
 
 #endif // CMD_MC_H


### PR DESCRIPTION
The C convention for the `main()` function is to pass in `argv` and `argc` like:

`int main(int argc, char **argv);`

I had flipped around the argument order, so this PR converts the code to match standard C syntax.