### PR TITLE
update the zero sequence terms of the transformation matrix

### DIFF
--- a/sdk/bare/common/sys/transform.c
+++ b/sdk/bare/common/sys/transform.c
@@ -25,7 +25,7 @@ void transform_dqz(double C, double theta, double *abc, double *dqz)
 
 void transform_dqz_inverse(double C, double theta, double *abc, double *dqz)
 {
-    abc[0] = C * (cos(theta)		*dqz[0] 	-sin(theta)			*dqz[1]) 	+	dqz[2]);
-    abc[1] = C * (cos(theta - PI23)	*dqz[0] 	-sin(theta - PI23)	*dqz[1]) 	+	dqz[2]);
-    abc[2] = C * (cos(theta + PI23)	*dqz[0] 	-sin(theta + PI23)	*dqz[1]) 	+	dqz[2]);
+    abc[0] = C * (cos(theta)		*dqz[0] 	-sin(theta)			*dqz[1]) 	+	dqz[2];
+    abc[1] = C * (cos(theta - PI23)	*dqz[0] 	-sin(theta - PI23)	*dqz[1]) 	+	dqz[2];
+    abc[2] = C * (cos(theta + PI23)	*dqz[0] 	-sin(theta + PI23)	*dqz[1]) 	+	dqz[2];
 }

--- a/sdk/bare/common/sys/transform.c
+++ b/sdk/bare/common/sys/transform.c
@@ -6,7 +6,7 @@ void transform_clarke(double C, double *abc, double *xyz)
 {
     xyz[0] = C * (1		*abc[0]			-0.5	*abc[1]			-0.5	*abc[2]);
     xyz[1] = C * (0		*abc[0]		+SQRT3/2	*abc[1]		-SQRT3/2	*abc[2]);
-    xyz[2] = C * (1/(3*C)	*abc[0]		+1/(3*C)	*abc[1]		+1/(3*C)	*abc[2]);
+    xyz[2] =     (1/3	*abc[0]		+1/3	    *abc[1]		+1/3	    *abc[2]);
 }
 
 void transform_park(double theta, double *xyz, double *dqz)
@@ -25,7 +25,7 @@ void transform_dqz(double C, double theta, double *abc, double *dqz)
 
 void transform_dqz_inverse(double C, double theta, double *abc, double *dqz)
 {
-    abc[0] = C * (cos(theta)			*dqz[0] 	-sin(theta)			*dqz[1] 	+(1/C)	*dqz[2]);
-    abc[1] = C * (cos(theta - PI23)	*dqz[0] 	-sin(theta - PI23)	*dqz[1] 	+(1/C)	*dqz[2]);
-    abc[2] = C * (cos(theta + PI23)	*dqz[0] 	-sin(theta + PI23)	*dqz[1] 	+(1/C)	*dqz[2]);
+    abc[0] = C * (cos(theta)		*dqz[0] 	-sin(theta)			*dqz[1]) 	+	dqz[2]);
+    abc[1] = C * (cos(theta - PI23)	*dqz[0] 	-sin(theta - PI23)	*dqz[1]) 	+	dqz[2]);
+    abc[2] = C * (cos(theta + PI23)	*dqz[0] 	-sin(theta + PI23)	*dqz[1]) 	+	dqz[2]);
 }

--- a/sdk/bare/common/sys/transform.c
+++ b/sdk/bare/common/sys/transform.c
@@ -6,7 +6,7 @@ void transform_clarke(double C, double *abc, double *xyz)
 {
     xyz[0] = C * (1		*abc[0]			-0.5	*abc[1]			-0.5	*abc[2]);
     xyz[1] = C * (0		*abc[0]		+SQRT3/2	*abc[1]		-SQRT3/2	*abc[2]);
-    xyz[2] = C * (1/SQRT2	*abc[0]		+1/SQRT2	*abc[1]		+1/SQRT2	*abc[2]);
+    xyz[2] = C * (1/(3*C)	*abc[0]		+1/(3*C)	*abc[1]		+1/(3*C)	*abc[2]);
 }
 
 void transform_park(double theta, double *xyz, double *dqz)
@@ -25,7 +25,7 @@ void transform_dqz(double C, double theta, double *abc, double *dqz)
 
 void transform_dqz_inverse(double C, double theta, double *abc, double *dqz)
 {
-    abc[0] = C * (cos(theta)			*dqz[0] 	-sin(theta)			*dqz[1] 	+(SQRT2/2)	*dqz[2]);
-    abc[1] = C * (cos(theta - PI23)	*dqz[0] 	-sin(theta - PI23)	*dqz[1] 	+(SQRT2/2)	*dqz[2]);
-    abc[2] = C * (cos(theta + PI23)	*dqz[0] 	-sin(theta + PI23)	*dqz[1] 	+(SQRT2/2)	*dqz[2]);
+    abc[0] = C * (cos(theta)			*dqz[0] 	-sin(theta)			*dqz[1] 	+(1/C)	*dqz[2]);
+    abc[1] = C * (cos(theta - PI23)	*dqz[0] 	-sin(theta - PI23)	*dqz[1] 	+(1/C)	*dqz[2]);
+    abc[2] = C * (cos(theta + PI23)	*dqz[0] 	-sin(theta + PI23)	*dqz[1] 	+(1/C)	*dqz[2]);
 }


### PR DESCRIPTION
This branch updates the zero-sequence current (I_0) to be `I_0 = (Ia + Ib + Ic)/3` . This is based on the textbook,
> "Vector control and dynamics of AC drives", D.W. Novotny and T.A Lipo. page 57-62.