### PR TITLE
Documentation of subfolders in repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,13 @@ The Advanced Motor Drive Controller (AMDC) is an open-source project from the [S
 
 AMDC is a next generation open-source hardware and software control platform for power electronics and motor drives, designed and developed for academic applications. AMDC contains high performance dual-core digital signal processors, tightly integrated custom digital logic (FPGA), and a plethora of extremely flexible inputs and outputs (I/O) designed to interface to motor drives. Low-level firmware drivers have been developed to abstract away the complexities of the software / hardware interface, letting users focus on implementing custom control algorithms. Common use-case controller code is provided which gets new users up and running efficiently. AMDC empowers engineers to control advanced systems with ease.
 
+## Getting Started
+
+The best way to get started with the AMDC platform is by throughly reading the documentation &mdash; see the next section.
+
 ## Documentation
 
-Documentation has been written to help ease the process of using the AMDC platform. To get started, recommendation is given to read the docs in the order listed below. Once you understand the general [firmware architecture](docs/Firmware-Architecture.md), try [downloading the code, building it, and running](docs/Building-and-Running-Firmware.md) an example application (i.e., [`blink`](sdk/bare/user/usr/blink/)) on the AMDC hardware. After your application is stable, try [flashing](docs/Flashing-AMDC.md) it to the AMDC hardware for permanent usage.
-
-If you run into low-level issues (i.e. strange restart issues), consider using the Xilinx [debugging tools](docs/Low-Level-Debugging.md) to investigate register state, etc.
-
-### [Firmware Architecture](docs/Firmware-Architecture.md)
-- [Drivers](docs/Firmware-Arch-Drivers.md)
-- [System](docs/Firmware-Arch-System.md)
-- [User Apps](docs/Firmware-Arch-UserApps.md)
-
-### [GitHub to AMDC Hardware: Building and Running Firmware](docs/Building-and-Running-Firmware.md)
-- [Create Private Repo](docs/Create-Private-Repo.md)
-
-### [Flashing AMDC](docs/Flashing-AMDC.md)
-
-### [Low-Level Debugging](docs/Low-Level-Debugging.md)
+Detailed documentation about the AMDC firmware is available in the `docs/` subfolder of this repo. [Check it out...](docs/)
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# Documentation
+
+Documentation has been written to help ease the process of using the AMDC platform. To get started, recommendation is given to read the docs in the order listed below. Once you understand the general [firmware architecture](docs/Firmware-Architecture.md), try [downloading the code, building it, and running](docs/Building-and-Running-Firmware.md) an example application (i.e., [`blink`](sdk/bare/user/usr/blink/)) on the AMDC hardware. After your application is stable, try [flashing](docs/Flashing-AMDC.md) it to the AMDC hardware for permanent usage.
+
+If you run into low-level issues (i.e. strange restart issues), consider using the Xilinx [debugging tools](docs/Low-Level-Debugging.md) to investigate register state, etc.
+
+## [Firmware Architecture](docs/Firmware-Architecture.md)
+- [Drivers](docs/Firmware-Arch-Drivers.md)
+- [System](docs/Firmware-Arch-System.md)
+- [User Apps](docs/Firmware-Arch-UserApps.md)
+
+## [GitHub to AMDC Hardware: Building and Running Firmware](docs/Building-and-Running-Firmware.md)
+- [Create Private Repo](docs/Create-Private-Repo.md)
+
+## [Flashing AMDC](docs/Flashing-AMDC.md)
+
+## [Low-Level Debugging](docs/Low-Level-Debugging.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,17 @@
 # Documentation
 
-Documentation has been written to help ease the process of using the AMDC platform. To get started, recommendation is given to read the docs in the order listed below. Once you understand the general [firmware architecture](docs/Firmware-Architecture.md), try [downloading the code, building it, and running](docs/Building-and-Running-Firmware.md) an example application (i.e., [`blink`](sdk/bare/user/usr/blink/)) on the AMDC hardware. After your application is stable, try [flashing](docs/Flashing-AMDC.md) it to the AMDC hardware for permanent usage.
+Documentation has been written to help ease the process of using the AMDC platform. To get started, recommendation is given to read the docs in the order listed below. Once you understand the general [firmware architecture](Firmware-Architecture.md), try [downloading the code, building it, and running](Building-and-Running-Firmware.md) an example application (i.e., [`blink`](../sdk/bare/user/usr/blink/)) on the AMDC hardware. After your application is stable, try [flashing](Flashing-AMDC.md) it to the AMDC hardware for permanent usage.
 
-If you run into low-level issues (i.e. strange restart issues), consider using the Xilinx [debugging tools](docs/Low-Level-Debugging.md) to investigate register state, etc.
+If you run into low-level issues (i.e. strange restart issues), consider using the Xilinx [debugging tools](Low-Level-Debugging.md) to investigate register state, etc.
 
-## [Firmware Architecture](docs/Firmware-Architecture.md)
-- [Drivers](docs/Firmware-Arch-Drivers.md)
-- [System](docs/Firmware-Arch-System.md)
-- [User Apps](docs/Firmware-Arch-UserApps.md)
+## [Firmware Architecture](Firmware-Architecture.md)
+- [Drivers](Firmware-Arch-Drivers.md)
+- [System](Firmware-Arch-System.md)
+- [User Apps](Firmware-Arch-UserApps.md)
 
-## [GitHub to AMDC Hardware: Building and Running Firmware](docs/Building-and-Running-Firmware.md)
-- [Create Private Repo](docs/Create-Private-Repo.md)
+## [GitHub to AMDC Hardware: Building and Running Firmware](Building-and-Running-Firmware.md)
+- [Create Private Repo](Create-Private-Repo.md)
 
-## [Flashing AMDC](docs/Flashing-AMDC.md)
+## [Flashing AMDC](Flashing-AMDC.md)
 
-## [Low-Level Debugging](docs/Low-Level-Debugging.md)
+## [Low-Level Debugging](Low-Level-Debugging.md)

--- a/hw/README.md
+++ b/hw/README.md
@@ -1,0 +1,11 @@
+# `hw/` Contents
+
+**All the FPGA project related files.**
+
+This folder contains the FPGA design resources needed to build the Xilinx Vivado project. This project is used to compile and build the FPGA bitstream needed for AMDC operation. Only a minimal number of files are needed since most of the platform-specific HDL is structured into IP blocks (see the [`ip_repo/`](../ip_repo/) folder).
+
+## File Description
+
+- `constraints_amdc_rev*.xdc` &mdash; stores the Vivado FPGA constraints (pin voltage levels + pin mappings to HDL netlist)
+- `design_1.bd` &mdash; main block diagram used in Vivado (stores logical structure of full FPGA contents)
+- `design_1_wrapper.v` &mdash; Verilog wrapper for the block diagram file. Generated based upon the block diagram.

--- a/hw/README.md
+++ b/hw/README.md
@@ -1,4 +1,4 @@
-# `hw/` Contents
+# Contents of `hw/`
 
 **All the FPGA project related files.**
 

--- a/ip_repo/README.md
+++ b/ip_repo/README.md
@@ -1,0 +1,31 @@
+# AMDC IP Repository
+
+This folder houses the IP for the AMDC platform. IP, or Intellectual Property, is the Xilinx term used to describe libraries of digital circuit design used in the FPGA fabric. These libraries are generally low-level interfaces to high-performance hardware (i.e. Ethernet, DDR4 memory, PCIe, etc) which Xilinx provides as drop-in blocks for user application designs. They communicate with the main system processor (DSP) via the AXI interconnect. See [this website](https://www.xilinx.com/products/intellectual-property.html) for more information about IP.
+
+The [AXI interconnect](https://www.xilinx.com/support/documentation/ip_documentation/ug761_axi_reference_guide.pdf) is the bus that goes between IP cores and the main processor. AXI is part of [ARM AMBA](https://en.wikipedia.org/wiki/Advanced_Microcontroller_Bus_Architecture), a family of microcontroller buses first introduced in 1996. AMBA 4.0, released in 2010, includes the second version of AXI, AXI4. Xilinx has adopted the Advanced eXtensible Interface (AXI) protocol for Intellectual Property (IP) cores.
+
+There are three types of AXI4 interfaces:
+
+1. AXI4 — for high-performance memory-mapped requirements
+2. AXI4-Lite — for simple, low-throughput memory-mapped communication (e.g., to and from control and status registers)
+3. AXI4-Stream — for high-speed streaming data.
+
+## IP Blocks
+
+The AMDC platform makes extensive use of the IP blocks to interface with the hardware peripherials on the circuit board. This includes PWM outputs, ADC inputs, encoders, SPIs, UARTs, and serially-addressable LEDs. These IP cores and their associated C drivers allow user applications, written in C, to easily control and interface to hardware. The AXI4-Lite interface is generally used for hardware interfacing on the AMDC. AXI4-Lite enables development of simple register-based peripherials.
+
+### `amdc_analog`
+
+This IP core is responsible for driving the external ADC on the AMDC hardware. The C driver let's the user configure the the sampling rate, alignment to PWM, and digital filtering. The latest digitized value for each channel is available to the C code via memory-mapped registers.
+
+### `amdc_dac`
+
+This IP core is responsible for driving a DAC expansion board plugged into the GPIO port on the AMDC hardware (REV C only). The core initially configures the external DAC device, then continously updates the digital values in the DAC based upon memory-mapped registers. These registers are settable via the C driver functions.
+
+### `amdc_encoder`
+
+This IP core interfaces to an incremental quadrature encoder (i.e. ABZ signals) to count the number of steps traveled over time. It also uses the Z index pulse to record absolute position. The position and step values are accessible to C code via memory-mapped registers.
+
+### `amdc_inverters`
+
+This IP core interfaces to the power stacks plugged into the AMDC hardware (up to 8x two-level three-phase inverters). Using the associated C driver, users can configure PWM switching characteristics (i.e. switching frequency and dead-time length). Duty ratios are set by users via memory-mapped registers. Four status lines per inverter are available via registers.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,16 @@
+# Contents of `scripts/`
+
+This folder contains miscellaneous scripts related to the AMDC firmware.
+
+## AMDC Python Class
+
+The AMDC can be interfaced to via the serial interface. This interface has been encapsulted into a simple python class which relies on the follow two files:
+
+1. `AMDC.py`
+2. `Mapfile.py`
+
+NOTE: these python scripts were built for compatibility with the `bare` DSP project.
+
+## Auto-Formatting C Code via `clang-format`
+
+The C code within `/sdk/bare/` is auto-formatted to keep a consistent coding style. See the [CONTRIBUTING](../CONTRIBUTING.md) file for information about how to use the auto-formater.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,20 @@
+# `sdk/` Contents
+
+This folder contains the C code used on the AMDC.
+
+Each folder is a complete project which can be compiled and ran on the Xilinx Zynq-7000 SoC. There are currently two projects:
+
+1. `basic` &mdash; C code written by Eric Severson for his PhD dissertation
+
+- Designed for BM control on PECB platform (similar to AMDC, but based on ZedBoard; developed at UMN)
+- Control performed in ISR context
+- Real-time Ethernet (lwIP) / serial logging capabilities
+
+2. `bare` &mdash; C code written by Nathan Petersen at UW-Madison
+
+- Designed for AMDC hardware platform (using PicoZed processor module)
+- Architecture based on generic tasks and commands
+- Custom-designed cooperative RTOS
+- User applications can be build neatly on top of RTOS without changed base code
+- Logging capabilities (store buffer + dump via serial)
+- Control algorithm injection point framework built into system

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -4,13 +4,13 @@ This folder contains the C code used on the AMDC.
 
 Each folder is a complete project which can be compiled and ran on the Xilinx Zynq-7000 SoC. There are currently two projects:
 
-1. `basic` &mdash; C code written by Eric Severson for his PhD dissertation
+1. `basic` &mdash; C code written by Eric Severson for his PhD dissertation (*archived and not maintained*)
 
 - Designed for BM control on PECB platform (similar to AMDC, but based on ZedBoard; developed at UMN)
 - Control performed in ISR context
 - Real-time Ethernet (lwIP) / serial logging capabilities
 
-2. `bare` &mdash; C code written by Nathan Petersen at UW-Madison
+2. `bare` &mdash; C code written by Nathan Petersen at UW-Madison (**actively maintained**)
 
 - Designed for AMDC hardware platform (using PicoZed processor module)
 - Architecture based on generic tasks and commands

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,6 +1,8 @@
 # `sdk/` Contents
 
-This folder contains the C code used on the AMDC.
+**All the DSP related files.**
+
+This folder contains the C code which is ran on the DSP on the AMDC hardware.
 
 Each folder is a complete project which can be compiled and ran on the Xilinx Zynq-7000 SoC. There are currently two projects:
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,4 +1,4 @@
-# `sdk/` Contents
+# Contents of `sdk/`
 
 **All the DSP related files.**
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -12,7 +12,7 @@ Each folder is a complete project which can be compiled and ran on the Xilinx Zy
 - Control performed in ISR context
 - Real-time Ethernet (lwIP) / serial logging capabilities
 
-2. `bare` &mdash; C code written by Nathan Petersen at UW-Madison (**actively maintained**)
+2. `bare` &mdash; minimal functionality, core framework for AMDC (**actively maintained**)
 
 - Designed for AMDC hardware platform (using PicoZed processor module)
 - Architecture based on generic tasks and commands

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -12,7 +12,7 @@ Each folder is a complete project which can be compiled and ran on the Xilinx Zy
 - Control performed in ISR context
 - Real-time Ethernet (lwIP) / serial logging capabilities
 
-2. `bare` &mdash; minimal functionality, core framework for AMDC (**actively maintained**)
+2. `bare` &mdash; Minimal functionality, core framework for AMDC (**actively maintained**)
 
 - Designed for AMDC hardware platform (using PicoZed processor module)
 - Architecture based on generic tasks and commands

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -6,9 +6,9 @@ This folder contains the C code which is ran on the DSP on the AMDC hardware.
 
 Each folder is a complete project which can be compiled and ran on the Xilinx Zynq-7000 SoC. There are currently two projects:
 
-1. `basic` &mdash; C code written by Eric Severson for his PhD dissertation (*archived and not maintained*)
+1. `basic` &mdash; Preliminary C code developed for ZedBoard (*archived and not maintained*)
 
-- Designed for BM control on PECB platform (similar to AMDC, but based on ZedBoard; developed at UMN)
+- Designed for BM control (based on ZedBoard)
 - Control performed in ISR context
 - Real-time Ethernet (lwIP) / serial logging capabilities
 


### PR DESCRIPTION
This PR adds more documentation to the repo (mostly just README files in each subfolder).

It also moves the main documentation TOC into the subfolder.

After this PR is merged, I will continue to restructure the `docs/` folder to be closer to that "chapter" idea we had.