### PR TITLE
Fix global variable

### DIFF
--- a/sdk/bare/common/sys/commands.c
+++ b/sdk/bare/common/sys/commands.c
@@ -47,7 +47,7 @@ static int pending_cmd_read_idx = 0;
 static int _command_handler(int argc, char **argv);
 
 // Head of linked list of commands
-command_entry_t *cmds = NULL;
+static command_entry_t *cmds = NULL;
 
 static task_control_block_t tcb_parse;
 static task_control_block_t tcb_exec;


### PR DESCRIPTION
Minor typo I found, this should be `static` so it isn't in the global namespace.