### PR TITLE
Separate code for REV D vs C

### DIFF
--- a/sdk/bare/common/drv/bsp.c
+++ b/sdk/bare/common/drv/bsp.c
@@ -1,6 +1,6 @@
 #include "usr/user_defines.h"
 
-#if (HARDWARE_REVISION == 3) || (HARDWARE_REVISION == 4)
+#if (HARDWARE_TARGET == 3) || (HARDWARE_TARGET == 4)
 // Ensure a valid hardware revision is specified
 // NOTE: this firmware only supports REV C hardware onward
 #else
@@ -11,8 +11,6 @@
 #include "drv/bsp.h"
 #include "drv/dac.h"
 #include "drv/encoder.h"
-#include "drv/gpio.h"
-#include "drv/io.h"
 #include "drv/pwm.h"
 #include "drv/timer.h"
 #include "drv/uart.h"
@@ -21,7 +19,12 @@
 #include "sys/defines.h"
 #include <stdio.h>
 
-#if HARDWARE_REVISION == 4
+#if HARDWARE_TARGET == 3
+#include "drv/gpio.h"
+#include "drv/io.h"
+#endif
+
+#if HARDWARE_TARGET == 4
 #include "drv/led.h"
 #endif
 
@@ -40,11 +43,11 @@ void bsp_init(void)
     analog_init();
     pwm_init();
 
-#if HARDWARE_REVISION == 4
+#if HARDWARE_TARGET == 4
     led_init();
 #endif
 
-#if HARDWARE_REVISION == 3
+#if HARDWARE_TARGET == 3
     io_init();
     gpio_init();
 #endif

--- a/sdk/bare/common/drv/bsp.c
+++ b/sdk/bare/common/drv/bsp.c
@@ -1,6 +1,7 @@
+#include "drv/hardware_targets.h"
 #include "usr/user_defines.h"
 
-#if (HARDWARE_TARGET == 3) || (HARDWARE_TARGET == 4)
+#if (HARDWARE_TARGET == AMDC_REV_C) || (HARDWARE_TARGET == AMDC_REV_D)
 // Ensure a valid hardware target is specified
 // NOTE: this firmware only supports REV C hardware onward
 #else
@@ -20,12 +21,12 @@
 #include "sys/defines.h"
 #include <stdio.h>
 
-#if HARDWARE_TARGET == 3
+#if HARDWARE_TARGET == AMDC_REV_C
 #include "drv/gpio.h"
 #include "drv/io.h"
 #endif
 
-#if HARDWARE_TARGET == 4
+#if HARDWARE_TARGET == AMDC_REV_D
 #include "drv/led.h"
 #endif
 
@@ -44,11 +45,11 @@ void bsp_init(void)
     analog_init();
     pwm_init();
 
-#if HARDWARE_TARGET == 4
+#if HARDWARE_TARGET == AMDC_REV_D
     led_init();
 #endif
 
-#if HARDWARE_TARGET == 3
+#if HARDWARE_TARGET == AMDC_REV_C
     io_init();
     gpio_init();
 #endif

--- a/sdk/bare/common/drv/bsp.c
+++ b/sdk/bare/common/drv/bsp.c
@@ -1,5 +1,14 @@
-#include "drv/bsp.h"
+#include "usr/user_defines.h"
+
+#if (HARDWARE_REVISION == 3) || (HARDWARE_REVISION == 4)
+// Ensure a valid hardware revision is specified
+// NOTE: this firmware only supports REV C hardware onward
+#else
+#error "ERROR: Hardware revision not specified correctly"
+#endif
+
 #include "drv/analog.h"
+#include "drv/bsp.h"
 #include "drv/dac.h"
 #include "drv/encoder.h"
 #include "drv/gpio.h"
@@ -10,8 +19,11 @@
 #include "drv/watchdog.h"
 #include "sys/cmd/cmd_hw.h"
 #include "sys/defines.h"
-#include "usr/user_defines.h"
 #include <stdio.h>
+
+#if HARDWARE_REVISION == 4
+#include "drv/led.h"
+#endif
 
 void bsp_init(void)
 {
@@ -27,9 +39,18 @@ void bsp_init(void)
     encoder_init();
     analog_init();
     pwm_init();
+
+#if HARDWARE_REVISION == 4
+    led_init();
+#endif
+
+#if HARDWARE_REVISION == 3
     io_init();
     gpio_init();
-    dac_init();
+#endif
+
+    // The DAC driver is current not supported on any hardware
+    // dac_init();
 
 #ifdef ENABLE_WATCHDOG
     watchdog_init();

--- a/sdk/bare/common/drv/bsp.c
+++ b/sdk/bare/common/drv/bsp.c
@@ -1,10 +1,11 @@
 #include "usr/user_defines.h"
 
 #if (HARDWARE_TARGET == 3) || (HARDWARE_TARGET == 4)
-// Ensure a valid hardware revision is specified
+// Ensure a valid hardware target is specified
 // NOTE: this firmware only supports REV C hardware onward
 #else
-#error "ERROR: Hardware revision not specified correctly"
+#error "ERROR: Hardware target not specified correctly"
+// If you have this error, please define HARDWARE_TARGET in your user_defines.h file!
 #endif
 
 #include "drv/analog.h"

--- a/sdk/bare/common/drv/dac.c
+++ b/sdk/bare/common/drv/dac.c
@@ -1,3 +1,5 @@
+#if 0
+
 #include "drv/dac.h"
 #include "xil_io.h"
 #include <stdio.h>
@@ -95,3 +97,5 @@ void dac_set_led(uint8_t idx, uint8_t state)
 
     Xil_Out32(DAC_BASE_ADDR + (8 * sizeof(uint32_t)), curr_led_state);
 }
+
+#endif

--- a/sdk/bare/common/drv/dac.h
+++ b/sdk/bare/common/drv/dac.h
@@ -1,3 +1,5 @@
+#if 0
+
 #ifndef DAC_H
 #define DAC_H
 
@@ -16,3 +18,5 @@ void dac_set_voltage_raw(uint8_t idx, uint16_t value);
 void dac_set_led(uint8_t idx, uint8_t state);
 
 #endif // DAC_H
+
+#endif

--- a/sdk/bare/common/drv/encoder.c
+++ b/sdk/bare/common/drv/encoder.c
@@ -1,4 +1,5 @@
 #include "drv/encoder.h"
+#include "drv/hardware_targets.h"
 #include "drv/io.h"
 #include "sys/defines.h"
 #include "sys/scheduler.h"
@@ -73,7 +74,7 @@ static void _find_z_callback(void *arg)
     {
         scheduler_tcb_unregister(&ctx->tcb);
 
-#if HARDWARE_TARGET == 3
+#if HARDWARE_TARGET == AMDC_REV_C
         io_led_color_t color;
         color.b = 0;
         io_led_set_c(0, 0, 1, &color);
@@ -90,7 +91,7 @@ void encoder_find_z(void)
     // Initialize the state machine context
     ctx.state = WAIT_UNTIL_Z;
 
-#if HARDWARE_TARGET == 3
+#if HARDWARE_TARGET == AMDC_REV_C
     io_led_color_t color;
     color.b = 255;
     io_led_set_c(0, 0, 1, &color);

--- a/sdk/bare/common/drv/encoder.c
+++ b/sdk/bare/common/drv/encoder.c
@@ -73,11 +73,11 @@ static void _find_z_callback(void *arg)
     {
         scheduler_tcb_unregister(&ctx->tcb);
 
-#if HARDWARE_REVISION == 3
+#if HARDWARE_TARGET == 3
         io_led_color_t color;
         color.b = 0;
         io_led_set_c(0, 0, 1, &color);
-#endif // HARDWARE_REVISION
+#endif // HARDWARE_TARGET
         break;
     }
     }
@@ -90,11 +90,11 @@ void encoder_find_z(void)
     // Initialize the state machine context
     ctx.state = WAIT_UNTIL_Z;
 
-#if HARDWARE_REVISION == 3
+#if HARDWARE_TARGET == 3
     io_led_color_t color;
     color.b = 255;
     io_led_set_c(0, 0, 1, &color);
-#endif // HARDWARE_REVISION
+#endif // HARDWARE_TARGET
 
     // Initialize the state machine callback tcb
     scheduler_tcb_init(&ctx.tcb, _find_z_callback, &ctx, "find_z", SM_INTERVAL_USEC);

--- a/sdk/bare/common/drv/encoder.c
+++ b/sdk/bare/common/drv/encoder.c
@@ -2,6 +2,7 @@
 #include "drv/io.h"
 #include "sys/defines.h"
 #include "sys/scheduler.h"
+#include "usr/user_defines.h"
 #include "xil_io.h"
 #include <math.h>
 #include <stdio.h>
@@ -72,10 +73,11 @@ static void _find_z_callback(void *arg)
     {
         scheduler_tcb_unregister(&ctx->tcb);
 
+#if HARDWARE_REVISION == 3
         io_led_color_t color;
         color.b = 0;
         io_led_set_c(0, 0, 1, &color);
-
+#endif // HARDWARE_REVISION
         break;
     }
     }
@@ -88,9 +90,11 @@ void encoder_find_z(void)
     // Initialize the state machine context
     ctx.state = WAIT_UNTIL_Z;
 
+#if HARDWARE_REVISION == 3
     io_led_color_t color;
     color.b = 255;
     io_led_set_c(0, 0, 1, &color);
+#endif // HARDWARE_REVISION
 
     // Initialize the state machine callback tcb
     scheduler_tcb_init(&ctx.tcb, _find_z_callback, &ctx, "find_z", SM_INTERVAL_USEC);

--- a/sdk/bare/common/drv/gpio.c
+++ b/sdk/bare/common/drv/gpio.c
@@ -1,6 +1,6 @@
 #include "usr/user_defines.h"
 
-#if HARDWARE_REVISION == 3
+#if HARDWARE_TARGET == 3
 
 #include "drv/gpio.h"
 #include "xgpiops.h"
@@ -82,4 +82,4 @@ void gpio_set_dir(uint8_t group, uint8_t dir)
     XGpioPs_WritePin(&Gpio, pin, dir);
 }
 
-#endif // HARDWARE_REVISION
+#endif // HARDWARE_TARGET

--- a/sdk/bare/common/drv/gpio.c
+++ b/sdk/bare/common/drv/gpio.c
@@ -1,3 +1,7 @@
+#include "usr/user_defines.h"
+
+#if HARDWARE_REVISION == 3
+
 #include "drv/gpio.h"
 #include "xgpiops.h"
 #include <stdio.h>
@@ -77,3 +81,5 @@ void gpio_set_dir(uint8_t group, uint8_t dir)
 
     XGpioPs_WritePin(&Gpio, pin, dir);
 }
+
+#endif // HARDWARE_REVISION

--- a/sdk/bare/common/drv/gpio.c
+++ b/sdk/bare/common/drv/gpio.c
@@ -1,6 +1,7 @@
+#include "drv/hardware_targets.h"
 #include "usr/user_defines.h"
 
-#if HARDWARE_TARGET == 3
+#if HARDWARE_TARGET == AMDC_REV_C
 
 #include "drv/gpio.h"
 #include "xgpiops.h"

--- a/sdk/bare/common/drv/gpio.h
+++ b/sdk/bare/common/drv/gpio.h
@@ -1,6 +1,10 @@
 #ifndef GPIO_H
 #define GPIO_H
 
+#include "usr/user_defines.h"
+
+#if HARDWARE_REVISION == 3
+
 #include <stdint.h>
 
 void gpio_init(void);
@@ -12,5 +16,7 @@ void gpio_port_read(uint8_t port, uint16_t *value);
 void gpio_port_write(uint8_t port, uint16_t value);
 
 void gpio_set_dir(uint8_t group, uint8_t dir);
+
+#endif // HARDWARE_REVISION
 
 #endif // GPIO_H

--- a/sdk/bare/common/drv/gpio.h
+++ b/sdk/bare/common/drv/gpio.h
@@ -1,9 +1,9 @@
-#ifndef GPIO_H
-#define GPIO_H
-
 #include "usr/user_defines.h"
 
-#if HARDWARE_REVISION == 3
+#if HARDWARE_TARGET == 3
+
+#ifndef GPIO_H
+#define GPIO_H
 
 #include <stdint.h>
 
@@ -17,6 +17,6 @@ void gpio_port_write(uint8_t port, uint16_t value);
 
 void gpio_set_dir(uint8_t group, uint8_t dir);
 
-#endif // HARDWARE_REVISION
-
 #endif // GPIO_H
+
+#endif // HARDWARE_TARGET

--- a/sdk/bare/common/drv/gpio.h
+++ b/sdk/bare/common/drv/gpio.h
@@ -1,6 +1,7 @@
+#include "drv/hardware_targets.h"
 #include "usr/user_defines.h"
 
-#if HARDWARE_TARGET == 3
+#if HARDWARE_TARGET == AMDC_REV_C
 
 #ifndef GPIO_H
 #define GPIO_H

--- a/sdk/bare/common/drv/hardware_targets.h
+++ b/sdk/bare/common/drv/hardware_targets.h
@@ -1,0 +1,11 @@
+#ifndef HARDWARE_TARGETS_H
+#define HARDWARE_TARGETS_H
+
+// This file holds the defines for all possible hardware targets.
+
+// As the AMDC platform matures, the supported hardware targets will change.
+
+#define AMDC_REV_C (3)
+#define AMDC_REV_D (4)
+
+#endif // HARDWARE_TARGETS_H

--- a/sdk/bare/common/drv/io.c
+++ b/sdk/bare/common/drv/io.c
@@ -1,6 +1,7 @@
+#include "drv/hardware_targets.h"
 #include "usr/user_defines.h"
 
-#if HARDWARE_TARGET == 3
+#if HARDWARE_TARGET == AMDC_REV_C
 
 #include "drv/io.h"
 #include "xgpiops.h"

--- a/sdk/bare/common/drv/io.c
+++ b/sdk/bare/common/drv/io.c
@@ -1,6 +1,6 @@
 #include "usr/user_defines.h"
 
-#if HARDWARE_REVISION == 3
+#if HARDWARE_TARGET == 3
 
 #include "drv/io.h"
 #include "xgpiops.h"
@@ -89,4 +89,4 @@ void io_button_get(uint8_t *btn1)
     *btn1 = XGpioPs_ReadPin(&Gpio, IO_BTN1_MIO_PIN);
 }
 
-#endif // HARDWARE_REVISION
+#endif // HARDWARE_TARGET

--- a/sdk/bare/common/drv/io.c
+++ b/sdk/bare/common/drv/io.c
@@ -1,3 +1,7 @@
+#include "usr/user_defines.h"
+
+#if HARDWARE_REVISION == 3
+
 #include "drv/io.h"
 #include "xgpiops.h"
 #include <stdio.h>
@@ -84,3 +88,5 @@ void io_button_get(uint8_t *btn1)
 {
     *btn1 = XGpioPs_ReadPin(&Gpio, IO_BTN1_MIO_PIN);
 }
+
+#endif // HARDWARE_REVISION

--- a/sdk/bare/common/drv/io.h
+++ b/sdk/bare/common/drv/io.h
@@ -1,9 +1,9 @@
-#ifndef IO_H
-#define IO_H
-
 #include "usr/user_defines.h"
 
-#if HARDWARE_REVISION == 3
+#if HARDWARE_TARGET == 3
+
+#ifndef IO_H
+#define IO_H
 
 #include <stdint.h>
 
@@ -21,6 +21,6 @@ void io_led_set(io_led_color_t *color);
 void io_switch_get(uint8_t *sw1, uint8_t *sw2);
 void io_button_get(uint8_t *btn1);
 
-#endif // HARDWARE_REVISION
-
 #endif // IO_H
+
+#endif // HARDWARE_TARGET

--- a/sdk/bare/common/drv/io.h
+++ b/sdk/bare/common/drv/io.h
@@ -1,6 +1,10 @@
 #ifndef IO_H
 #define IO_H
 
+#include "usr/user_defines.h"
+
+#if HARDWARE_REVISION == 3
+
 #include <stdint.h>
 
 typedef struct io_led_color_t {
@@ -16,5 +20,7 @@ void io_led_set(io_led_color_t *color);
 
 void io_switch_get(uint8_t *sw1, uint8_t *sw2);
 void io_button_get(uint8_t *btn1);
+
+#endif // HARDWARE_REVISION
 
 #endif // IO_H

--- a/sdk/bare/common/drv/io.h
+++ b/sdk/bare/common/drv/io.h
@@ -1,6 +1,7 @@
+#include "drv/hardware_targets.h"
 #include "usr/user_defines.h"
 
-#if HARDWARE_TARGET == 3
+#if HARDWARE_TARGET == AMDC_REV_C
 
 #ifndef IO_H
 #define IO_H

--- a/sdk/bare/common/drv/led.c
+++ b/sdk/bare/common/drv/led.c
@@ -1,0 +1,80 @@
+#include "usr/user_defines.h"
+
+#if HARDWARE_REVISION == 4
+
+#include "drv/led.h"
+#include "xil_io.h"
+#include <stdint.h>
+
+#define LED_BASE_ADDR (0x43C30000)
+
+// Color Data Bit Format
+// =====================
+//
+// NOTE: see datasheet for bit ordering:
+//
+// 24-bit data format
+//
+// MSB -- G8R8B8 -- LSB
+//
+// Bits 23-16 : green
+// Bits 15-8  : red
+// Bits 7-0   : blue
+
+void led_init(void)
+{
+    // Turn off all LEDs to start
+    for (uint8_t i = 0; i < NUM_LEDS; i++) {
+        led_set_raw(i, 0);
+    }
+}
+
+void led_set_color(led_t idx, led_color_t color)
+{
+    uint32_t raw = 0;
+    raw |= ((uint32_t) color.g & 0x000000FF) << 16;
+    raw |= ((uint32_t) color.r & 0x000000FF) << 8;
+    raw |= ((uint32_t) color.b & 0x000000FF) << 0;
+
+    led_set_raw(idx, raw);
+}
+
+void led_set_color_bytes(led_t idx, uint8_t r, uint8_t g, uint8_t b)
+{
+    uint32_t raw = 0;
+    raw |= ((uint32_t) g & 0x000000FF) << 16;
+    raw |= ((uint32_t) r & 0x000000FF) << 8;
+    raw |= ((uint32_t) b & 0x000000FF) << 0;
+
+    led_set_raw(idx, raw);
+}
+
+void led_set_raw(led_t idx, uint32_t color)
+{
+    // NOTE: Writing color values to the device registers will
+    // automatically trigger the transmission of color data
+    // out to the LEDs.
+    //
+    // The user does not have to manually trigger the transmission.
+
+    Xil_Out32(LED_BASE_ADDR + (idx * sizeof(uint32_t)), color);
+}
+
+led_color_t led_get_color(led_t idx)
+{
+    uint32_t raw = led_get_raw(idx);
+
+    led_color_t ret;
+    ret.g = (raw & 0x00FF0000) >> 16;
+    ret.r = (raw & 0x0000FF00) >> 8;
+    ret.b = (raw & 0x000000FF) >> 0;
+
+    return ret;
+}
+
+uint32_t led_get_raw(led_t idx)
+{
+    return Xil_In32(LED_BASE_ADDR + (idx * sizeof(uint32_t)));
+}
+
+#endif // HARDWARE_REVISION

--- a/sdk/bare/common/drv/led.c
+++ b/sdk/bare/common/drv/led.c
@@ -1,6 +1,7 @@
+#include "drv/hardware_targets.h"
 #include "usr/user_defines.h"
 
-#if HARDWARE_TARGET == 4
+#if HARDWARE_TARGET == AMDC_REV_D
 
 #include "drv/led.h"
 #include "xil_io.h"

--- a/sdk/bare/common/drv/led.c
+++ b/sdk/bare/common/drv/led.c
@@ -1,6 +1,6 @@
 #include "usr/user_defines.h"
 
-#if HARDWARE_REVISION == 4
+#if HARDWARE_TARGET == 4
 
 #include "drv/led.h"
 #include "xil_io.h"
@@ -77,4 +77,4 @@ uint32_t led_get_raw(led_t idx)
     return Xil_In32(LED_BASE_ADDR + (idx * sizeof(uint32_t)));
 }
 
-#endif // HARDWARE_REVISION
+#endif // HARDWARE_TARGET

--- a/sdk/bare/common/drv/led.h
+++ b/sdk/bare/common/drv/led.h
@@ -1,0 +1,46 @@
+#ifndef LED_H
+#define LED_H
+
+#include "usr/user_defines.h"
+
+#if HARDWARE_REVISION == 4
+
+#include <stdint.h>
+
+typedef struct led_color_t {
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+} led_color_t;
+
+// clang-format off
+static const led_color_t LED_COLOR_RED     = { 020, 000, 000 };
+static const led_color_t LED_COLOR_GREEN   = { 000, 020, 000 };
+static const led_color_t LED_COLOR_BLUE    = { 000, 000, 020 };
+static const led_color_t LED_COLOR_YELLOW  = { 020, 020, 000 };
+static const led_color_t LED_COLOR_CYAN    = { 000, 020, 020 };
+static const led_color_t LED_COLOR_MAGENTA = { 020, 000, 020 };
+static const led_color_t LED_COLOR_WHITE   = { 020, 020, 020 };
+static const led_color_t LED_COLOR_BLACK   = { 000, 000, 000 };
+// clang-format on
+
+typedef enum {
+    LED0 = 0,
+    LED1,
+    LED2,
+    LED3,
+    NUM_LEDS,
+} led_t;
+
+void led_init(void);
+
+void led_set_color(led_t idx, led_color_t color);
+void led_set_color_bytes(led_t idx, uint8_t r, uint8_t g, uint8_t b);
+void led_set_raw(led_t idx, uint32_t color);
+
+led_color_t led_get_color(led_t idx);
+uint32_t led_get_raw(led_t idx);
+
+#endif // HARDWARE_REVISION
+
+#endif // LED_H

--- a/sdk/bare/common/drv/led.h
+++ b/sdk/bare/common/drv/led.h
@@ -1,6 +1,7 @@
+#include "drv/hardware_targets.h"
 #include "usr/user_defines.h"
 
-#if HARDWARE_TARGET == 4
+#if HARDWARE_TARGET == AMDC_REV_D
 
 #ifndef LED_H
 #define LED_H

--- a/sdk/bare/common/drv/led.h
+++ b/sdk/bare/common/drv/led.h
@@ -1,9 +1,9 @@
-#ifndef LED_H
-#define LED_H
-
 #include "usr/user_defines.h"
 
-#if HARDWARE_REVISION == 4
+#if HARDWARE_TARGET == 4
+
+#ifndef LED_H
+#define LED_H
 
 #include <stdint.h>
 
@@ -41,6 +41,6 @@ void led_set_raw(led_t idx, uint32_t color);
 led_color_t led_get_color(led_t idx);
 uint32_t led_get_raw(led_t idx);
 
-#endif // HARDWARE_REVISION
-
 #endif // LED_H
+
+#endif // HARDWARE_TARGET

--- a/sdk/bare/common/sys/cmd/cmd_hw.c
+++ b/sdk/bare/common/sys/cmd/cmd_hw.c
@@ -1,17 +1,29 @@
-#include "cmd_hw.h"
+#include "sys/cmd/cmd_hw.h"
 #include "drv/analog.h"
 #include "drv/encoder.h"
 #include "drv/pwm.h"
 #include "sys/commands.h"
 #include "sys/debug.h"
 #include "sys/defines.h"
+#include "usr/user_defines.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
+#if HARDWARE_REVISION == 4
+#include "drv/led.h"
+#endif // HARDWARE_REVISION
+
 static command_entry_t cmd_entry;
 
+#if HARDWARE_REVISION == 3
 #define NUM_HELP_ENTRIES (6)
+#endif // HARDWARE_REVISION
+
+#if HARDWARE_REVISION == 4
+#define NUM_HELP_ENTRIES (7)
+#endif // HARDWARE_REVISION
+
 static command_help_t cmd_help[NUM_HELP_ENTRIES] = {
     { "pwm sw <freq_switching> <deadtime_ns>", "Set the PWM switching characteristics" },
     { "pwm duty <pwm_idx> <percent>", "Set a duty ratio" },
@@ -19,6 +31,10 @@ static command_help_t cmd_help[NUM_HELP_ENTRIES] = {
     { "enc steps", "Read encoder steps from power-up" },
     { "enc pos", "Read encoder position" },
     { "enc init", "Turn on blue LED until Z pulse found" },
+
+#if HARDWARE_REVISION == 4
+    { "led set <led_idx> <r> <g> <b>", "Set LED color (color is 0..255)" },
+#endif // HARDWARE_REVISION
 };
 
 void cmd_hw_register(void)
@@ -110,6 +126,33 @@ int cmd_hw(int argc, char **argv)
             return SUCCESS;
         }
     }
+
+#if HARDWARE_REVISION == 4
+    // Handle 'led' sub-command
+    // hw led set <led_idx> <r> <g> <b>
+    if (argc == 7 && strcmp("led", argv[1]) == 0) {
+        if (strcmp("set", argv[2]) == 0) {
+            int led_idx = atoi(argv[3]);
+            if (led_idx < 0 || led_idx >= NUM_LEDS)
+                return INVALID_ARGUMENTS;
+
+            int r = atoi(argv[4]);
+            int g = atoi(argv[5]);
+            int b = atoi(argv[6]);
+
+            if (r < 0 || r > 255)
+                return INVALID_ARGUMENTS;
+            if (g < 0 || g > 255)
+                return INVALID_ARGUMENTS;
+            if (b < 0 || b > 255)
+                return INVALID_ARGUMENTS;
+
+            led_set_color_bytes(led_idx, r, g, b);
+
+            return SUCCESS;
+        }
+    }
+#endif // HARDWARE_REVISION
 
     // Handle 'enc' sub-command
     if (strcmp("enc", argv[1]) == 0) {

--- a/sdk/bare/common/sys/cmd/cmd_hw.c
+++ b/sdk/bare/common/sys/cmd/cmd_hw.c
@@ -1,6 +1,7 @@
 #include "sys/cmd/cmd_hw.h"
 #include "drv/analog.h"
 #include "drv/encoder.h"
+#include "drv/hardware_targets.h"
 #include "drv/pwm.h"
 #include "sys/commands.h"
 #include "sys/debug.h"
@@ -11,7 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if HARDWARE_TARGET == 4
+#if HARDWARE_TARGET == AMDC_REV_D
 #include "drv/led.h"
 #endif // HARDWARE_TARGET
 
@@ -25,7 +26,7 @@ static command_help_t cmd_help[] = {
     { "enc pos", "Read encoder position" },
     { "enc init", "Turn on blue LED until Z pulse found" },
 
-#if HARDWARE_TARGET == 4
+#if HARDWARE_TARGET == AMDC_REV_D
     { "led set <led_idx> <r> <g> <b>", "Set LED color (color is 0..255)" },
 #endif // HARDWARE_TARGET
 };
@@ -120,7 +121,7 @@ int cmd_hw(int argc, char **argv)
         }
     }
 
-#if HARDWARE_TARGET == 4
+#if HARDWARE_TARGET == AMDC_REV_D
     // Handle 'led' sub-command
     // hw led set <led_idx> <r> <g> <b>
     if (argc == 7 && strcmp("led", argv[1]) == 0) {

--- a/sdk/bare/common/sys/cmd/cmd_hw.c
+++ b/sdk/bare/common/sys/cmd/cmd_hw.c
@@ -11,9 +11,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if HARDWARE_REVISION == 4
+#if HARDWARE_TARGET == 4
 #include "drv/led.h"
-#endif // HARDWARE_REVISION
+#endif // HARDWARE_TARGET
 
 static command_entry_t cmd_entry;
 
@@ -25,9 +25,9 @@ static command_help_t cmd_help[] = {
     { "enc pos", "Read encoder position" },
     { "enc init", "Turn on blue LED until Z pulse found" },
 
-#if HARDWARE_REVISION == 4
+#if HARDWARE_TARGET == 4
     { "led set <led_idx> <r> <g> <b>", "Set LED color (color is 0..255)" },
-#endif // HARDWARE_REVISION
+#endif // HARDWARE_TARGET
 };
 
 void cmd_hw_register(void)
@@ -120,7 +120,7 @@ int cmd_hw(int argc, char **argv)
         }
     }
 
-#if HARDWARE_REVISION == 4
+#if HARDWARE_TARGET == 4
     // Handle 'led' sub-command
     // hw led set <led_idx> <r> <g> <b>
     if (argc == 7 && strcmp("led", argv[1]) == 0) {
@@ -145,7 +145,7 @@ int cmd_hw(int argc, char **argv)
             return SUCCESS;
         }
     }
-#endif // HARDWARE_REVISION
+#endif // HARDWARE_TARGET
 
     // Handle 'enc' sub-command
     if (strcmp("enc", argv[1]) == 0) {

--- a/sdk/bare/common/sys/cmd/cmd_hw.c
+++ b/sdk/bare/common/sys/cmd/cmd_hw.c
@@ -5,6 +5,7 @@
 #include "sys/commands.h"
 #include "sys/debug.h"
 #include "sys/defines.h"
+#include "sys/util.h"
 #include "usr/user_defines.h"
 #include <stdint.h>
 #include <stdlib.h>
@@ -16,15 +17,7 @@
 
 static command_entry_t cmd_entry;
 
-#if HARDWARE_REVISION == 3
-#define NUM_HELP_ENTRIES (6)
-#endif // HARDWARE_REVISION
-
-#if HARDWARE_REVISION == 4
-#define NUM_HELP_ENTRIES (7)
-#endif // HARDWARE_REVISION
-
-static command_help_t cmd_help[NUM_HELP_ENTRIES] = {
+static command_help_t cmd_help[] = {
     { "pwm sw <freq_switching> <deadtime_ns>", "Set the PWM switching characteristics" },
     { "pwm duty <pwm_idx> <percent>", "Set a duty ratio" },
     { "anlg read <chnl_idx>", "Read voltage on ADC channel" },
@@ -40,7 +33,7 @@ static command_help_t cmd_help[NUM_HELP_ENTRIES] = {
 void cmd_hw_register(void)
 {
     // Populate the command entry block
-    commands_cmd_init(&cmd_entry, "hw", "Hardware related commands", cmd_help, NUM_HELP_ENTRIES, cmd_hw);
+    commands_cmd_init(&cmd_entry, "hw", "Hardware related commands", cmd_help, ARRAY_SIZE(cmd_help), cmd_hw);
 
     // Register the command
     commands_cmd_register(&cmd_entry);

--- a/sdk/bare/common/sys/cmd/cmd_inj.c
+++ b/sdk/bare/common/sys/cmd/cmd_inj.c
@@ -6,13 +6,13 @@
 #include "sys/commands.h"
 #include "sys/defines.h"
 #include "sys/injection.h"
+#include "sys/util.h"
 #include <stdlib.h>
 #include <string.h>
 
 static command_entry_t cmd_entry;
 
-#define NUM_HELP_ENTRIES (6)
-static command_help_t cmd_help[NUM_HELP_ENTRIES] = {
+static command_help_t cmd_help[] = {
     { "clear", "Clear all injections" },
     { "list", "List all available injection points" },
     { "const <name> <set|add|sub> <mValue>", "Inject a constant" },
@@ -24,7 +24,7 @@ static command_help_t cmd_help[NUM_HELP_ENTRIES] = {
 void cmd_inj_register(void)
 {
     // Populate the command entry block
-    commands_cmd_init(&cmd_entry, "inj", "Inject signals into system", cmd_help, NUM_HELP_ENTRIES, cmd_inj);
+    commands_cmd_init(&cmd_entry, "inj", "Inject signals into system", cmd_help, ARRAY_SIZE(cmd_help), cmd_inj);
 
     // Register the command
     commands_cmd_register(&cmd_entry);

--- a/sdk/bare/common/sys/cmd/cmd_log.c
+++ b/sdk/bare/common/sys/cmd/cmd_log.c
@@ -6,14 +6,14 @@
 #include "sys/commands.h"
 #include "sys/defines.h"
 #include "sys/log.h"
+#include "sys/util.h"
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
 static command_entry_t cmd_entry;
 
-#define NUM_HELP_ENTRIES (5)
-static command_help_t cmd_help[NUM_HELP_ENTRIES] = {
+static command_help_t cmd_help[] = {
     { "reg <log_var_idx> <name> <memory_addr> <samples_per_sec> <type>", "Register memory address for logging" },
     { "start", "Start logging" },
     { "stop", "Stop logging" },
@@ -24,7 +24,7 @@ static command_help_t cmd_help[NUM_HELP_ENTRIES] = {
 void cmd_log_register(void)
 {
     // Populate the command entry block
-    commands_cmd_init(&cmd_entry, "log", "Logging engine commands", cmd_help, NUM_HELP_ENTRIES, cmd_log);
+    commands_cmd_init(&cmd_entry, "log", "Logging engine commands", cmd_help, ARRAY_SIZE(cmd_help), cmd_log);
 
     // Register the command
     commands_cmd_register(&cmd_entry);

--- a/sdk/bare/common/sys/commands.c
+++ b/sdk/bare/common/sys/commands.c
@@ -7,6 +7,7 @@
 #include "sys/log.h"
 #include "sys/scheduler.h"
 #include "sys/serial.h"
+#include "sys/util.h"
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>

--- a/sdk/bare/common/sys/defines.h
+++ b/sdk/bare/common/sys/defines.h
@@ -10,9 +10,6 @@
 #define SEC_TO_USEC(sec)  (sec * USEC_IN_SEC)
 #define USEC_TO_SEC(usec) (usec / USEC_IN_SEC)
 
-#define MIN(x, y) (((x) > (y)) ? (y) : (x))
-#define MAX(x, y) (((x) > (y)) ? (x) : (y))
-
 #define HANG                                                                                                           \
     printf("HANG!!!\n");                                                                                               \
     while (1)

--- a/sdk/bare/common/sys/log.c
+++ b/sdk/bare/common/sys/log.c
@@ -7,6 +7,7 @@
 #include "sys/defines.h"
 #include "sys/log.h"
 #include "sys/scheduler.h"
+#include "sys/util.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/sdk/bare/common/sys/serial.c
+++ b/sdk/bare/common/sys/serial.c
@@ -1,6 +1,7 @@
 #include "sys/serial.h"
 #include "drv/uart.h"
 #include "sys/scheduler.h"
+#include "sys/util.h"
 #include <string.h>
 
 #define OUTPUT_BUFFER_LENGTH (32 * 1024)

--- a/sdk/bare/common/sys/util.c
+++ b/sdk/bare/common/sys/util.c
@@ -1,0 +1,1 @@
+#include "sys/util.h"

--- a/sdk/bare/common/sys/util.h
+++ b/sdk/bare/common/sys/util.h
@@ -1,0 +1,9 @@
+#ifndef UTIL_H
+#define UTIL_H
+
+#define MIN(x, y) (((x) > (y)) ? (y) : (x))
+#define MAX(x, y) (((x) > (y)) ? (x) : (y))
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+
+#endif // UTIL_H

--- a/sdk/bare/common/usr/demo/cmd/cmd_cc.c
+++ b/sdk/bare/common/usr/demo/cmd/cmd_cc.c
@@ -6,6 +6,7 @@
 #include "sys/commands.h"
 #include "sys/debug.h"
 #include "sys/defines.h"
+#include "sys/util.h"
 #include "usr/demo/task_cc.h"
 #include <stdbool.h>
 #include <stdlib.h>
@@ -38,8 +39,7 @@ float value;
 
 static command_entry_t cmd_entry;
 
-#define NUM_HELP_ENTRIES (8)
-static command_help_t cmd_help[NUM_HELP_ENTRIES] = {
+static command_help_t cmd_help[] = {
     { "setup [ashad|yusuke]", "Set-up specific bench configuration" },
     { "<cc_idx> init", "Initialize current controller" },
     { "<cc_idx> deinit", "Deinitialize current controller" },
@@ -52,7 +52,8 @@ static command_help_t cmd_help[NUM_HELP_ENTRIES] = {
 
 void cmd_cc_register(void)
 {
-    commands_cmd_init(&cmd_entry, "cc", "Current control (D/Q) related commands", cmd_help, NUM_HELP_ENTRIES, cmd_cc);
+    commands_cmd_init(
+        &cmd_entry, "cc", "Current control (D/Q) related commands", cmd_help, ARRAY_SIZE(cmd_help), cmd_cc);
 
     // Register the command with the system
     commands_cmd_register(&cmd_entry);

--- a/sdk/bare/common/usr/demo/inverter.c
+++ b/sdk/bare/common/usr/demo/inverter.c
@@ -1,6 +1,7 @@
 #ifdef APP_DEMO
 
 #include "usr/demo/inverter.h"
+#include "drv/hardware_targets.h"
 #include "drv/io.h"
 #include "drv/pwm.h"
 #include "usr/user_defines.h"
@@ -42,7 +43,7 @@ void inverter_saturate_to_Vdc(int inv_idx, double *phase_voltage)
         ctx->Vdc = 1.0;
     }
 
-#if HARDWARE_TARGET == 3
+#if HARDWARE_TARGET == AMDC_REV_C
     io_led_color_t color = { 0, 0, 0 };
     if (saturate(-ctx->Vdc / 2.0, ctx->Vdc / 2.0, phase_voltage) != 0)
         color.g = 255;

--- a/sdk/bare/common/usr/demo/inverter.c
+++ b/sdk/bare/common/usr/demo/inverter.c
@@ -3,6 +3,7 @@
 #include "usr/demo/inverter.h"
 #include "drv/io.h"
 #include "drv/pwm.h"
+#include "usr/user_defines.h"
 #include <math.h>
 
 typedef struct inverter_ctx_t {
@@ -41,10 +42,12 @@ void inverter_saturate_to_Vdc(int inv_idx, double *phase_voltage)
         ctx->Vdc = 1.0;
     }
 
+#if HARDWARE_REVISION == 3
     io_led_color_t color = { 0, 0, 0 };
     if (saturate(-ctx->Vdc / 2.0, ctx->Vdc / 2.0, phase_voltage) != 0)
         color.g = 255;
     io_led_set_c(0, 1, 0, &color);
+#endif // HARDWARE_REVISION
 }
 
 void inverter_set_voltage(int inv_idx, uint8_t pwm_idx, double phase_voltage)

--- a/sdk/bare/common/usr/demo/inverter.c
+++ b/sdk/bare/common/usr/demo/inverter.c
@@ -42,12 +42,12 @@ void inverter_saturate_to_Vdc(int inv_idx, double *phase_voltage)
         ctx->Vdc = 1.0;
     }
 
-#if HARDWARE_REVISION == 3
+#if HARDWARE_TARGET == 3
     io_led_color_t color = { 0, 0, 0 };
     if (saturate(-ctx->Vdc / 2.0, ctx->Vdc / 2.0, phase_voltage) != 0)
         color.g = 255;
     io_led_set_c(0, 1, 0, &color);
-#endif // HARDWARE_REVISION
+#endif // HARDWARE_TARGET
 }
 
 void inverter_set_voltage(int inv_idx, uint8_t pwm_idx, double phase_voltage)

--- a/sdk/bare/user/.cproject
+++ b/sdk/bare/user/.cproject
@@ -29,7 +29,6 @@
 								<option id="xilinx.gnu.compiler.inferred.swplatform.flags.390797143" name="Software Platform Inferred Flags" superClass="xilinx.gnu.compiler.inferred.swplatform.flags" value="-Wl,--start-group,-lxil,-lgcc,-lc,--end-group" valueType="string"/>
 								<option id="xilinx.gnu.compiler.misc.other.1858768302" name="Other flags" superClass="xilinx.gnu.compiler.misc.other" value="-c -fmessage-length=0 -MT&quot;$@&quot; -mcpu=cortex-a9 -mfpu=vfpv3 -mfloat-abi=hard" valueType="string"/>
 								<option id="xilinx.gnu.compiler.symbols.defined.1897050119" name="Defined symbols (-D)" superClass="xilinx.gnu.compiler.symbols.defined" valueType="definedSymbols">
-									<listOptionValue builtIn="false" value="APP_DEMO"/>
 									<listOptionValue builtIn="false" value="APP_BLINK"/>
 								</option>
 								<option id="xilinx.gnu.compiler.dircategory.includes.1596529872" name="Include Paths" superClass="xilinx.gnu.compiler.dircategory.includes" valueType="includePath">

--- a/sdk/bare/user/.cproject
+++ b/sdk/bare/user/.cproject
@@ -30,6 +30,7 @@
 								<option id="xilinx.gnu.compiler.misc.other.1858768302" name="Other flags" superClass="xilinx.gnu.compiler.misc.other" value="-c -fmessage-length=0 -MT&quot;$@&quot; -mcpu=cortex-a9 -mfpu=vfpv3 -mfloat-abi=hard" valueType="string"/>
 								<option id="xilinx.gnu.compiler.symbols.defined.1897050119" name="Defined symbols (-D)" superClass="xilinx.gnu.compiler.symbols.defined" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="APP_DEMO"/>
+									<listOptionValue builtIn="false" value="APP_BLINK"/>
 								</option>
 								<option id="xilinx.gnu.compiler.dircategory.includes.1596529872" name="Include Paths" superClass="xilinx.gnu.compiler.dircategory.includes" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/amdc_bsp/ps7_cortexa9_0/include}&quot;"/>

--- a/sdk/bare/user/usr/blink/cmd/cmd_blink.c
+++ b/sdk/bare/user/usr/blink/cmd/cmd_blink.c
@@ -4,6 +4,7 @@
 #include "sys/commands.h"
 #include "sys/debug.h"
 #include "sys/defines.h"
+#include "usr/blink/task_blink.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -12,9 +13,12 @@ static command_entry_t cmd_entry;
 
 // Defines help content displayed for this command
 // when user types "help" at command prompt
-#define NUM_HELP_ENTRIES (1)
+#define NUM_HELP_ENTRIES (3)
 static command_help_t cmd_help[NUM_HELP_ENTRIES] = {
     { "hello <name>", "Print hello to screen" },
+    { "init", "Start task" },
+    { "deinit", "Stop task" },
+
 };
 
 void cmd_blink_register(void)
@@ -89,6 +93,16 @@ int cmd_blink(int argc, char **argv)
         }
 
         // If user typed a valid command, return SUCCESS
+        return SUCCESS;
+    }
+
+    if (argc == 2 && strcmp("init", argv[1]) == 0) {
+        task_blink_init();
+        return SUCCESS;
+    }
+
+    if (argc == 2 && strcmp("deinit", argv[1]) == 0) {
+        task_blink_deinit();
         return SUCCESS;
     }
 

--- a/sdk/bare/user/usr/blink/cmd/cmd_blink.c
+++ b/sdk/bare/user/usr/blink/cmd/cmd_blink.c
@@ -4,6 +4,7 @@
 #include "sys/commands.h"
 #include "sys/debug.h"
 #include "sys/defines.h"
+#include "sys/util.h"
 #include "usr/blink/task_blink.h"
 #include <stdlib.h>
 #include <string.h>
@@ -13,8 +14,7 @@ static command_entry_t cmd_entry;
 
 // Defines help content displayed for this command
 // when user types "help" at command prompt
-#define NUM_HELP_ENTRIES (3)
-static command_help_t cmd_help[NUM_HELP_ENTRIES] = {
+static command_help_t cmd_help[] = {
     { "hello <name>", "Print hello to screen" },
     { "init", "Start task" },
     { "deinit", "Stop task" },
@@ -27,7 +27,7 @@ void cmd_blink_register(void)
     //
     // Here is where you define the base command string: "blink"
     // and what function is called to handle command
-    commands_cmd_init(&cmd_entry, "blink", "Blink application commands", cmd_help, NUM_HELP_ENTRIES, cmd_blink);
+    commands_cmd_init(&cmd_entry, "blink", "Blink application commands", cmd_help, ARRAY_SIZE(cmd_help), cmd_blink);
 
     // Register the command with the system
     commands_cmd_register(&cmd_entry);

--- a/sdk/bare/user/usr/blink/task_blink.c
+++ b/sdk/bare/user/usr/blink/task_blink.c
@@ -1,12 +1,38 @@
 #ifdef APP_BLINK
 
 #include "usr/blink/task_blink.h"
-#include "drv/io.h"
 #include "sys/scheduler.h"
+#include "usr/user_defines.h"
 #include <stdint.h>
 
+#if HARDWARE_REVISION == 4
+#include "drv/led.h"
+#endif // HARDWARE_REVISION
+
+#if HARDWARE_REVISION == 3
+#include "drv/io.h"
+#endif // HARDWARE_REVISION
+
+#if HARDWARE_REVISION == 3
 // Hold LED state (0: off, 1: red, 2: green, 3: blue)
 static uint8_t led_state = 0;
+#endif // HARDWARE_REVISION
+
+#if HARDWARE_REVISION == 4
+// Hold LED animation state
+static uint8_t led_pos = 0;
+static uint8_t led_color_idx = 0;
+#define NUM_LED_COLORS (7)
+static led_color_t led_colors[NUM_LED_COLORS] = {
+    LED_COLOR_RED,     //
+    LED_COLOR_GREEN,   //
+    LED_COLOR_BLUE,    //
+    LED_COLOR_YELLOW,  //
+    LED_COLOR_CYAN,    //
+    LED_COLOR_MAGENTA, //
+    LED_COLOR_WHITE,   //
+};
+#endif // HARDWARE_REVISION
 
 // Scheduler TCB which holds task "context"
 static task_control_block_t tcb;
@@ -20,8 +46,30 @@ void task_blink_init(void)
     scheduler_tcb_register(&tcb);
 }
 
+void task_blink_deinit(void)
+{
+    if (!scheduler_tcb_is_registered(&tcb)) {
+        return;
+    }
+
+    // Register task with scheduler
+    scheduler_tcb_unregister(&tcb);
+
+#if HARDWARE_REVISION == 4
+    // Turn off all LEDs
+    for (uint8_t i = 0; i < NUM_LEDS; i++) {
+        led_set_color(i, LED_COLOR_BLACK);
+    }
+
+    // Reset state
+    led_pos = 0;
+    led_color_idx = 0;
+#endif // HARDWARE_REVISION
+}
+
 void task_blink_callback(void *arg)
 {
+#if HARDWARE_REVISION == 3
     // Set LED output via I/O driver
     io_led_color_t color = { 0 };
     color.r = led_state == 1 ? 1 : 0;
@@ -33,6 +81,21 @@ void task_blink_callback(void *arg)
     if (++led_state >= 4) {
         led_state = 0;
     }
+#endif // HARDWARE_REVISION
+
+#if HARDWARE_REVISION == 4
+    for (uint8_t i = 0; i < NUM_LEDS; i++) {
+        led_set_color(i, led_pos == i ? led_colors[led_color_idx] : LED_COLOR_BLACK);
+    }
+
+    if (++led_pos == NUM_LEDS) {
+        led_pos = 0;
+
+        if (++led_color_idx >= NUM_LED_COLORS) {
+            led_color_idx = 0;
+        }
+    }
+#endif // HARDWARE_REVISION
 }
 
 #endif // APP_BLINK

--- a/sdk/bare/user/usr/blink/task_blink.c
+++ b/sdk/bare/user/usr/blink/task_blink.c
@@ -1,24 +1,25 @@
 #ifdef APP_BLINK
 
 #include "usr/blink/task_blink.h"
+#include "drv/hardware_targets.h"
 #include "sys/scheduler.h"
 #include "usr/user_defines.h"
 #include <stdint.h>
 
-#if HARDWARE_TARGET == 4
+#if HARDWARE_TARGET == AMDC_REV_D
 #include "drv/led.h"
 #endif // HARDWARE_TARGET
 
-#if HARDWARE_TARGET == 3
+#if HARDWARE_TARGET == AMDC_REV_C
 #include "drv/io.h"
 #endif // HARDWARE_TARGET
 
-#if HARDWARE_TARGET == 3
+#if HARDWARE_TARGET == AMDC_REV_C
 // Hold LED state (0: off, 1: red, 2: green, 3: blue)
 static uint8_t led_state = 0;
 #endif // HARDWARE_TARGET
 
-#if HARDWARE_TARGET == 4
+#if HARDWARE_TARGET == AMDC_REV_D
 // Hold LED animation state
 static uint8_t led_pos = 0;
 static uint8_t led_color_idx = 0;
@@ -55,7 +56,7 @@ void task_blink_deinit(void)
     // Register task with scheduler
     scheduler_tcb_unregister(&tcb);
 
-#if HARDWARE_TARGET == 4
+#if HARDWARE_TARGET == AMDC_REV_D
     // Turn off all LEDs
     for (uint8_t i = 0; i < NUM_LEDS; i++) {
         led_set_color(i, LED_COLOR_BLACK);
@@ -69,7 +70,7 @@ void task_blink_deinit(void)
 
 void task_blink_callback(void *arg)
 {
-#if HARDWARE_TARGET == 3
+#if HARDWARE_TARGET == AMDC_REV_C
     // Set LED output via I/O driver
     io_led_color_t color = { 0 };
     color.r = led_state == 1 ? 1 : 0;
@@ -83,7 +84,7 @@ void task_blink_callback(void *arg)
     }
 #endif // HARDWARE_TARGET
 
-#if HARDWARE_TARGET == 4
+#if HARDWARE_TARGET == AMDC_REV_D
     for (uint8_t i = 0; i < NUM_LEDS; i++) {
         led_set_color(i, led_pos == i ? led_colors[led_color_idx] : LED_COLOR_BLACK);
     }

--- a/sdk/bare/user/usr/blink/task_blink.c
+++ b/sdk/bare/user/usr/blink/task_blink.c
@@ -5,20 +5,20 @@
 #include "usr/user_defines.h"
 #include <stdint.h>
 
-#if HARDWARE_REVISION == 4
+#if HARDWARE_TARGET == 4
 #include "drv/led.h"
-#endif // HARDWARE_REVISION
+#endif // HARDWARE_TARGET
 
-#if HARDWARE_REVISION == 3
+#if HARDWARE_TARGET == 3
 #include "drv/io.h"
-#endif // HARDWARE_REVISION
+#endif // HARDWARE_TARGET
 
-#if HARDWARE_REVISION == 3
+#if HARDWARE_TARGET == 3
 // Hold LED state (0: off, 1: red, 2: green, 3: blue)
 static uint8_t led_state = 0;
-#endif // HARDWARE_REVISION
+#endif // HARDWARE_TARGET
 
-#if HARDWARE_REVISION == 4
+#if HARDWARE_TARGET == 4
 // Hold LED animation state
 static uint8_t led_pos = 0;
 static uint8_t led_color_idx = 0;
@@ -32,7 +32,7 @@ static led_color_t led_colors[NUM_LED_COLORS] = {
     LED_COLOR_MAGENTA, //
     LED_COLOR_WHITE,   //
 };
-#endif // HARDWARE_REVISION
+#endif // HARDWARE_TARGET
 
 // Scheduler TCB which holds task "context"
 static task_control_block_t tcb;
@@ -55,7 +55,7 @@ void task_blink_deinit(void)
     // Register task with scheduler
     scheduler_tcb_unregister(&tcb);
 
-#if HARDWARE_REVISION == 4
+#if HARDWARE_TARGET == 4
     // Turn off all LEDs
     for (uint8_t i = 0; i < NUM_LEDS; i++) {
         led_set_color(i, LED_COLOR_BLACK);
@@ -64,12 +64,12 @@ void task_blink_deinit(void)
     // Reset state
     led_pos = 0;
     led_color_idx = 0;
-#endif // HARDWARE_REVISION
+#endif // HARDWARE_TARGET
 }
 
 void task_blink_callback(void *arg)
 {
-#if HARDWARE_REVISION == 3
+#if HARDWARE_TARGET == 3
     // Set LED output via I/O driver
     io_led_color_t color = { 0 };
     color.r = led_state == 1 ? 1 : 0;
@@ -81,9 +81,9 @@ void task_blink_callback(void *arg)
     if (++led_state >= 4) {
         led_state = 0;
     }
-#endif // HARDWARE_REVISION
+#endif // HARDWARE_TARGET
 
-#if HARDWARE_REVISION == 4
+#if HARDWARE_TARGET == 4
     for (uint8_t i = 0; i < NUM_LEDS; i++) {
         led_set_color(i, led_pos == i ? led_colors[led_color_idx] : LED_COLOR_BLACK);
     }
@@ -95,7 +95,7 @@ void task_blink_callback(void *arg)
             led_color_idx = 0;
         }
     }
-#endif // HARDWARE_REVISION
+#endif // HARDWARE_TARGET
 }
 
 #endif // APP_BLINK

--- a/sdk/bare/user/usr/blink/task_blink.h
+++ b/sdk/bare/user/usr/blink/task_blink.h
@@ -8,7 +8,7 @@
 // Must be less than or equal to scheduler updates per second
 // This value is defined in sys/scheduler.h and defaults to 10kHz.
 // Note that it can be overridden via usr/user_defines.h
-#define TASK_BLINK_UPDATES_PER_SEC (1)
+#define TASK_BLINK_UPDATES_PER_SEC (5)
 
 // Microseconds interval between when task is called
 //
@@ -18,6 +18,7 @@
 
 // Called in app init function to set up task (or via command)
 void task_blink_init(void);
+void task_blink_deinit(void);
 
 // Callback function which scheduler calls periodically
 void task_blink_callback(void *arg);

--- a/sdk/bare/user/usr/user_defines.h
+++ b/sdk/bare/user/usr/user_defines.h
@@ -7,7 +7,7 @@
 
 // Specify hardware revision (i.e. REV C, REV D, etc)
 // Alphabet to number: A = 1, B = 2, C = 3, etc
-#define HARDWARE_REVISION (3)
+#define HARDWARE_TARGET (3)
 
 // Override the default scheduler elementary
 // frequency by defining SYS_TICK_FREQ here:

--- a/sdk/bare/user/usr/user_defines.h
+++ b/sdk/bare/user/usr/user_defines.h
@@ -1,13 +1,14 @@
 #ifndef USER_DEFINES_H
 #define USER_DEFINES_H
 
+#include "drv/hardware_targets.h"
+
 //
 // This file is used to override system defines.
 //
 
-// Specify hardware revision (i.e. REV C, REV D, etc)
-// Alphabet to number: A = 1, B = 2, C = 3, etc
-#define HARDWARE_TARGET (3)
+// Specify hardware revision (from drv/hardware_targets.h)
+#define HARDWARE_TARGET AMDC_REV_C
 
 // Override the default scheduler elementary
 // frequency by defining SYS_TICK_FREQ here:

--- a/sdk/bare/user/usr/user_defines.h
+++ b/sdk/bare/user/usr/user_defines.h
@@ -7,7 +7,7 @@
 
 // Specify hardware revision (i.e. REV C, REV D, etc)
 // Alphabet to number: A = 1, B = 2, C = 3, etc
-#define HARDWARE_REVISION (4)
+#define HARDWARE_REVISION (3)
 
 // Override the default scheduler elementary
 // frequency by defining SYS_TICK_FREQ here:

--- a/sdk/bare/user/usr/user_defines.h
+++ b/sdk/bare/user/usr/user_defines.h
@@ -5,6 +5,10 @@
 // This file is used to override system defines.
 //
 
+// Specify hardware revision (i.e. REV C, REV D, etc)
+// Alphabet to number: A = 1, B = 2, C = 3, etc
+#define HARDWARE_REVISION (4)
+
 // Override the default scheduler elementary
 // frequency by defining SYS_TICK_FREQ here:
 //#define SYS_TICK_FREQ (20000) // Hz


### PR DESCRIPTION
This PR implements separation of C code for the different hardware revision. This allows users to compile the project for either the REV C or REV D hardware target.

To set the target, the user must update their `user_defines.h` file with the correct `HARDWARE_REVISION` define.

Note that it assumes the AXI interface to the FPGA has the same addresses for both REV C and D bitstreams. I believe this is a valid assumption!