### PR TITLE
Improve default task stats behavior

### DIFF
--- a/sdk/bare/common/sys/scheduler.c
+++ b/sdk/bare/common/sys/scheduler.c
@@ -69,8 +69,11 @@ void scheduler_tcb_init(
     tcb->interval_usec = interval_usec;
     tcb->last_run_usec = 0;
 
-    // Always turn on the task statistics!
+#if USER_CONFIG_ENABLE_TASK_STATISTICS_BY_DEFAULT == 1
     tcb->stats.enabled = true;
+#else
+    tcb->stats.enabled = false;
+#endif // USER_CONFIG_ENABLE_TASK_STATISTICS_BY_DEFAULT
 }
 
 void scheduler_tcb_register(task_control_block_t *tcb)

--- a/sdk/bare/common/sys/task_stats.c
+++ b/sdk/bare/common/sys/task_stats.c
@@ -60,11 +60,13 @@ void task_stats_post_task(task_stats_t *stats)
 typedef enum sm_states_e {
     PRINT_HEADER = 0,
 
+    PRINT_LOOP_NUM_SAMPLES,
     PRINT_LOOP_MIN,
     PRINT_LOOP_MAX,
     PRINT_LOOP_MEAN,
     PRINT_LOOP_VARIANCE,
 
+    PRINT_RUN_NUM_SAMPLES,
     PRINT_RUN_MIN,
     PRINT_RUN_MAX,
     PRINT_RUN_MEAN,
@@ -90,11 +92,16 @@ void state_machine_callback(void *arg)
     switch (ctx->state) {
     case PRINT_HEADER:
         debug_printf("Task Stats:\r\n");
-        ctx->state = PRINT_LOOP_MIN;
+        ctx->state = PRINT_LOOP_NUM_SAMPLES;
         break;
 
     // Loop timings
     // ...
+    case PRINT_LOOP_NUM_SAMPLES:
+        debug_printf("Loop Num:\t%d samples\r\n", ctx->stats->loop_time.num_samples);
+        ctx->state = PRINT_LOOP_MIN;
+        break;
+
     case PRINT_LOOP_MIN:
         debug_printf("Loop Min:\t%.2f usec\r\n", ctx->stats->loop_time.min);
         ctx->state = PRINT_LOOP_MAX;
@@ -112,11 +119,16 @@ void state_machine_callback(void *arg)
 
     case PRINT_LOOP_VARIANCE:
         debug_printf("Loop Var:\t%.2f usec\r\n", statistics_variance(&ctx->stats->loop_time));
-        ctx->state = PRINT_RUN_MIN;
+        ctx->state = PRINT_RUN_NUM_SAMPLES;
         break;
 
     // Run timings
     // ...
+    case PRINT_RUN_NUM_SAMPLES:
+        debug_printf("Run Num:\t%d samples\r\n", ctx->stats->run_time.num_samples);
+        ctx->state = PRINT_RUN_MIN;
+        break;
+
     case PRINT_RUN_MIN:
         debug_printf("Run Min:\t%.2f usec\r\n", ctx->stats->run_time.min);
         ctx->state = PRINT_RUN_MAX;

--- a/sdk/bare/user/usr/user_config.h
+++ b/sdk/bare/user/usr/user_config.h
@@ -17,6 +17,11 @@
 // set to 1 for enabled, 0 for disabled
 #define USER_CONFIG_ENABLE_TIME_QUANTUM_CHECKING (1)
 
+// Enable task statistic collection by default
+// NOTE: The user can still go and enable the stats themselves if this is set to 0!
+// set to 1 for enabled, 0 for disabled
+#define USER_CONFIG_ENABLE_TASK_STATISTICS_BY_DEFAULT (0)
+
 // Enable the watchdog timer
 // set to 1 for enabled, 0 for disabled
 #define USER_CONFIG_ENABLE_WATCHDOG (0)


### PR DESCRIPTION
This PR makes it so that task statistics collection is turned off by default (this saves time slice time). If the user wants to turn it on, they have to change a define in their `usr/user_config.h` file.

This PR also makes the print function display the number of samples the statistics are calculated over.