### PR TITLE
Fix bug where unreg slot still persist samples

### DIFF
--- a/sdk/bare/common/sys/log.c
+++ b/sdk/bare/common/sys/log.c
@@ -179,7 +179,12 @@ int log_var_unregister(int idx)
         return FAILURE;
     }
 
+    // Mark as unregistered, this allows slot to be reused
     vars[idx].is_registered = false;
+
+    // Also, empty slot so when variable is rereg the next time,
+    // previous samples aren't still stored.
+    log_var_empty(idx);
 
     return SUCCESS;
 }


### PR DESCRIPTION
Per @Nick-Hemenway demo today, I noticed a slight bug in the logging system.

When the user unreg a slot that has samples stored in it, then rereg that same slot to a new variable, then calls `info`, it will look like the new variable has samples already. These are from the previous variable and never got cleared out.

This PR clears out those old samples when a slot is unreg.