### PR TITLE
Scheduler clean up

### DIFF
--- a/sdk/bare/common/sys/log.c
+++ b/sdk/bare/common/sys/log.c
@@ -32,7 +32,7 @@ typedef struct log_var_t {
     var_type_e type;
 
     uint32_t log_interval_usec;
-    uint64_t last_logged_usec;
+    uint32_t last_logged_usec;
 
     int num_samples;
     buffer_entry_t buffer[LOG_VARIABLE_SAMPLE_DEPTH];
@@ -94,7 +94,7 @@ void log_callback(void *arg)
         return;
     }
 
-    uint64_t elapsed_usec = scheduler_get_elapsed_usec();
+    uint32_t elapsed_usec = scheduler_get_elapsed_usec();
 
     for (uint8_t i = 0; i < LOG_MAX_NUM_VARS; i++) {
         log_var_t *v = &vars[i];
@@ -104,7 +104,7 @@ void log_callback(void *arg)
             continue;
         }
 
-        uint64_t usec_since_last_run = elapsed_usec - v->last_logged_usec;
+        uint32_t usec_since_last_run = elapsed_usec - v->last_logged_usec;
 
         if (usec_since_last_run >= v->log_interval_usec) {
             // Time to log this variable!

--- a/sdk/bare/common/sys/scheduler.c
+++ b/sdk/bare/common/sys/scheduler.c
@@ -18,7 +18,7 @@ static task_control_block_t *tasks = NULL;
 static task_control_block_t *running_task = NULL;
 
 // Incremented every SysTick interrupt to track time
-static uint64_t elapsed_usec = 0;
+static uint32_t elapsed_usec = 0;
 
 static bool tasks_running = false;
 static volatile bool scheduler_idle = false;
@@ -45,7 +45,7 @@ void scheduler_timer_isr(void *userParam, uint8_t TmrCtrNumber)
     scheduler_idle = false;
 }
 
-uint64_t scheduler_get_elapsed_usec(void)
+uint32_t scheduler_get_elapsed_usec(void)
 {
     return elapsed_usec;
 }
@@ -155,7 +155,7 @@ void scheduler_run(void)
 
         task_control_block_t *t = tasks;
         while (t != NULL) {
-            uint64_t usec_since_last_run = elapsed_usec - t->last_run_usec;
+            uint32_t usec_since_last_run = elapsed_usec - t->last_run_usec;
 
             if (usec_since_last_run >= t->interval_usec) {
                 // Time to run this task!

--- a/sdk/bare/common/sys/scheduler.c
+++ b/sdk/bare/common/sys/scheduler.c
@@ -1,6 +1,7 @@
 #include "sys/scheduler.h"
 #include "drv/hardware_targets.h"
 #include "drv/io.h"
+#include "drv/led.h"
 #include "drv/timer.h"
 #include "drv/watchdog.h"
 #include "usr/user_config.h"
@@ -29,6 +30,7 @@ void scheduler_timer_isr(void *userParam, uint8_t TmrCtrNumber)
     // We should be done running tasks in a time slice before this fires,
     // so if tasks are still running, we consumed too many cycles per slice
     if (tasks_running) {
+        // Use raw printf so this goes directly to the UART device
         printf("ERROR: OVERRUN SCHEDULER TIME QUANTUM!\n");
 #if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_C
         io_led_color_t color;
@@ -36,8 +38,17 @@ void scheduler_timer_isr(void *userParam, uint8_t TmrCtrNumber)
         color.g = 0;
         color.b = 0;
         io_led_set(&color);
+#elif USER_CONFIG_HARDWARE_TARGET == AMDC_REV_D
+        led_set_color(0, LED_COLOR_RED);
+        led_set_color(1, LED_COLOR_RED);
+        led_set_color(2, LED_COLOR_RED);
+        led_set_color(3, LED_COLOR_RED);
 #endif // USER_CONFIG_HARDWARE_TARGET
-        HANG;
+
+        // Hang here so the user can debug why the code took so long
+        // and overran the time slice! See the `running_task` variable.
+        while (1) {
+        }
     }
 #endif // USER_CONFIG_ENABLE_TIME_QUANTUM_CHECKING
 
@@ -76,52 +87,54 @@ void scheduler_tcb_init(
 #endif // USER_CONFIG_ENABLE_TASK_STATISTICS_BY_DEFAULT
 }
 
-void scheduler_tcb_register(task_control_block_t *tcb)
+int scheduler_tcb_register(task_control_block_t *tcb)
 {
     // Don't let clients re-register their tcb
-    if (tcb->registered) {
-        HANG;
+    if (tcb->is_registered) {
+        return FAILURE;
     }
 
     // Mark as registered
-    tcb->registered = 1;
+    tcb->is_registered = true;
 
-    // Base case: there are no tasks in linked list
     if (tasks == NULL) {
+        // There are no tasks in linked list
         tasks = tcb;
         tasks->next = NULL;
-        return;
+    } else {
+        // Find end of list
+        task_control_block_t *curr = tasks;
+        while (curr->next != NULL) {
+            curr = curr->next;
+        }
+
+        // Append new tcb to end of list
+        curr->next = tcb;
+        tcb->next = NULL;
     }
 
-    // Find end of list
-    task_control_block_t *curr = tasks;
-    while (curr->next != NULL)
-        curr = curr->next;
-
-    // Append new tcb to end of list
-    curr->next = tcb;
-    tcb->next = NULL;
+    return SUCCESS;
 }
 
-void scheduler_tcb_unregister(task_control_block_t *tcb)
+int scheduler_tcb_unregister(task_control_block_t *tcb)
 {
     // Don't let clients unregister their already unregistered tcb
-    if (!tcb->registered) {
-        HANG;
+    if (!tcb->is_registered) {
+        return FAILURE;
     }
-
-    // Mark as unregistered
-    tcb->registered = 0;
 
     // Make sure list isn't empty
     if (tasks == NULL) {
-        HANG;
+        return FAILURE;
     }
+
+    // Mark as unregistered
+    tcb->is_registered = false;
 
     // Special case: trying to remove the head of the list
     if (tasks->id == tcb->id) {
         tasks = tasks->next;
-        return;
+        return SUCCESS;
     }
 
     // Now we know that 'tcb' to remove is NOT first node
@@ -138,11 +151,13 @@ void scheduler_tcb_unregister(task_control_block_t *tcb)
     // 'curr' is now the one we want to remove!
 
     prev->next = curr->next;
+
+    return SUCCESS;
 }
 
-uint8_t scheduler_tcb_is_registered(task_control_block_t *tcb)
+bool scheduler_tcb_is_registered(task_control_block_t *tcb)
 {
-    return tcb->registered;
+    return tcb->is_registered;
 }
 
 void scheduler_run(void)

--- a/sdk/bare/common/sys/scheduler.h
+++ b/sdk/bare/common/sys/scheduler.h
@@ -29,8 +29,8 @@ typedef struct task_control_block_t {
     uint8_t registered;
     task_callback_t callback;
     void *callback_arg;
-    uint64_t interval_usec;
-    uint64_t last_run_usec;
+    uint32_t interval_usec;
+    uint32_t last_run_usec;
 
     task_stats_t stats;
 
@@ -46,6 +46,6 @@ void scheduler_tcb_register(task_control_block_t *tcb);
 void scheduler_tcb_unregister(task_control_block_t *tcb);
 uint8_t scheduler_tcb_is_registered(task_control_block_t *tcb);
 
-uint64_t scheduler_get_elapsed_usec(void);
+uint32_t scheduler_get_elapsed_usec(void);
 
 #endif // SCHEDULER_H

--- a/sdk/bare/common/sys/scheduler.h
+++ b/sdk/bare/common/sys/scheduler.h
@@ -1,6 +1,7 @@
 #ifndef SCHEDULER_H
 #define SCHEDULER_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "sys/defines.h"
@@ -26,7 +27,7 @@ typedef void (*task_callback_t)(void *);
 typedef struct task_control_block_t {
     int id;
     const char *name;
-    uint8_t registered;
+    bool is_registered;
     task_callback_t callback;
     void *callback_arg;
     uint32_t interval_usec;
@@ -42,9 +43,9 @@ void scheduler_run(void);
 
 void scheduler_tcb_init(
     task_control_block_t *tcb, task_callback_t callback, void *callback_arg, const char *name, uint32_t interval_usec);
-void scheduler_tcb_register(task_control_block_t *tcb);
-void scheduler_tcb_unregister(task_control_block_t *tcb);
-uint8_t scheduler_tcb_is_registered(task_control_block_t *tcb);
+int scheduler_tcb_register(task_control_block_t *tcb);
+int scheduler_tcb_unregister(task_control_block_t *tcb);
+bool scheduler_tcb_is_registered(task_control_block_t *tcb);
 
 uint32_t scheduler_get_elapsed_usec(void);
 

--- a/sdk/bare/user/usr/blink/cmd/cmd_blink.c
+++ b/sdk/bare/user/usr/blink/cmd/cmd_blink.c
@@ -99,24 +99,30 @@ int cmd_blink(int argc, char **argv)
     }
 
     if (argc == 2 && strcmp("init", argv[1]) == 0) {
-        task_blink_init();
-        return SUCCESS;
+        if (task_blink_init() != SUCCESS) {
+            return CMD_FAILURE;
+        }
+
+        return CMD_SUCCESS;
     }
 
     if (argc == 2 && strcmp("deinit", argv[1]) == 0) {
-        task_blink_deinit();
-        return SUCCESS;
+        if (task_blink_deinit() != SUCCESS) {
+            return CMD_FAILURE;
+        }
+
+        return CMD_SUCCESS;
     }
 
     if (argc >= 2 && strcmp("stats", argv[1]) == 0) {
         if (argc == 3 && strcmp("print", argv[2]) == 0) {
             task_blink_stats_print();
-            return SUCCESS;
+            return CMD_SUCCESS;
         }
 
         if (argc == 3 && strcmp("reset", argv[2]) == 0) {
             task_blink_stats_reset();
-            return SUCCESS;
+            return CMD_SUCCESS;
         }
     }
 

--- a/sdk/bare/user/usr/blink/task_blink.c
+++ b/sdk/bare/user/usr/blink/task_blink.c
@@ -39,24 +39,17 @@ static led_color_t led_colors[NUM_LED_COLORS] = {
 // Scheduler TCB which holds task "context"
 static task_control_block_t tcb;
 
-void task_blink_init(void)
+int task_blink_init(void)
 {
     // Fill TCB with parameters
     scheduler_tcb_init(&tcb, task_blink_callback, NULL, "blink", TASK_BLINK_INTERVAL_USEC);
 
     // Register task with scheduler
-    scheduler_tcb_register(&tcb);
+    return scheduler_tcb_register(&tcb);
 }
 
-void task_blink_deinit(void)
+int task_blink_deinit(void)
 {
-    if (!scheduler_tcb_is_registered(&tcb)) {
-        return;
-    }
-
-    // Register task with scheduler
-    scheduler_tcb_unregister(&tcb);
-
 #if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_D
     // Turn off all LEDs
     for (uint8_t i = 0; i < NUM_LEDS; i++) {
@@ -67,6 +60,9 @@ void task_blink_deinit(void)
     led_pos = 0;
     led_color_idx = 0;
 #endif // USER_CONFIG_HARDWARE_TARGET
+
+    // Unregister task with scheduler
+    return scheduler_tcb_unregister(&tcb);
 }
 
 void task_blink_callback(void *arg)

--- a/sdk/bare/user/usr/blink/task_blink.h
+++ b/sdk/bare/user/usr/blink/task_blink.h
@@ -7,7 +7,7 @@
 //
 // Must be less than or equal to scheduler updates per second
 // This value is defined in sys/scheduler.h and defaults to 10kHz.
-// Note that it can be overridden via usr/user_defines.h
+// Note that it can be overridden via usr/user_config.h
 #define TASK_BLINK_UPDATES_PER_SEC (5)
 
 // Microseconds interval between when task is called
@@ -17,8 +17,8 @@
 #define TASK_BLINK_INTERVAL_USEC (USEC_IN_SEC / TASK_BLINK_UPDATES_PER_SEC)
 
 // Called in app init function to set up task (or via command)
-void task_blink_init(void);
-void task_blink_deinit(void);
+int task_blink_init(void);
+int task_blink_deinit(void);
 
 // Callback function which scheduler calls periodically
 void task_blink_callback(void *arg);


### PR DESCRIPTION
This PR makes the AMDC firmware safer by adding return codes to the `sys/scheduler.c` API. Now, the user can check if the call was successful or not. The scheduler now **does not `HANG`** under any circumstances.

This PR also changes the scheduler time base to 32-bit number from 64-bit number. The AMDC processor does not support 64 bit numbers natively, and there is no need to use them. In the case of wrapping, the `uint32_t` math gracefully handles this.