### PR TITLE
Restructure Python logging internals 

### DIFF
--- a/scripts/AMDC.py
+++ b/scripts/AMDC.py
@@ -37,6 +37,16 @@ class AMDC:
     def __enter__(self):
         self.connect()
         return self
+    
+    def print_outputs(self, val = True):
+        self.printOutput = val
+        
+    def print_cmds(self, val = True):
+        self.cmdEcho = val
+        
+    def print_all(self, val = True):
+        self.print_outputs(val)
+        self.print_cmds(val)
 
     def __exit__(self, type, value, traceback):
         self.disconnect()

--- a/scripts/AMDC.py
+++ b/scripts/AMDC.py
@@ -1,14 +1,21 @@
 import serial
 import time
-    
+
+
 class AMDC:
-    def __init__(self, port, baudrate = '115200',
-                            cmdDelay = 0.2, cmdDelayChar = 0.001,
-                            cmdEcho = True, cmdEchoPrepend = "\t> ",
-                            printOutput = True, outputPrepend = "",
-                            captureOutput = True):
+    def __init__(self,
+                 port,
+                 baudrate='115200',
+                 cmdDelay=0.2,
+                 cmdDelayChar=0.001,
+                 cmdEcho=True,
+                 cmdEchoPrepend="\t> ",
+                 printOutput=True,
+                 outputPrepend="",
+                 captureOutput=True):
+
         # Serial port configuration
-        self.ser = serial.Serial(timeout = 0)
+        self.ser = serial.Serial(timeout=0)
         self.ser.baudrate = baudrate
         self.ser.port = port
 
@@ -26,7 +33,7 @@ class AMDC:
 
     def disconnect(self):
         self.ser.close()
-        
+
     def __enter__(self):
         self.connect()
         return self
@@ -39,33 +46,36 @@ class AMDC:
         to_send_bytes = str.encode(to_send_str)
         for b in to_send_bytes:
             self.ser.write(bytes([b]))
-            
+
             # Pause between letters so we don't send data too fast
             time.sleep(self.cmdDelayChar)
-        
+
         # Wait for cmd to execute on AMDC
         time.sleep(self.cmdDelay)
-        
+
         # Print log for user
         if self.cmdEcho:
             print(f"{self.cmdEchoPrepend}{cmd_str}")
 
         if self.captureOutput:
             #Print out any feedback from command
-            output = [] #empty array for output that's returned from command
+            output = []  #empty array for output that's returned from command
             count_empty = 0  #number of empty lines in a row
-            allowed_empty = 10 #the code will keep reading lines until it reaches 
-                                #this many consecutive blank lines
+            allowed_empty = 10  #the code will keep reading lines until it reaches
+            #this many consecutive blank lines
             while count_empty < allowed_empty:
 
-                line = self.ser.readline().decode() #read in line and decode
+                line = self.ser.readline().decode()  #read in line and decode
 
-                if len(line)>0 and line != '\n': #if line is not empty and not just new line
-                    line = line.strip('\n\r') #remove newline and carriage returns
-                    output.append(line) #append line to output list
+                if len(
+                        line
+                ) > 0 and line != '\n':  #if line is not empty and not just new line
+                    line = line.strip(
+                        '\n\r')  #remove newline and carriage returns
+                    output.append(line)  #append line to output list
                     count_empty = 0
                 else:
-                    count_empty +=1
+                    count_empty += 1
 
             if self.printOutput:
                 print(f"{self.outputPrepend}{output}")
@@ -73,9 +83,9 @@ class AMDC:
             return output
 
 
-
 def main():
-    
-    pass    
-    
+
+    pass
+
+
 if __name__ == '__main__': main()

--- a/scripts/AMDC_Logger.py
+++ b/scripts/AMDC_Logger.py
@@ -81,15 +81,15 @@ class AMDC_Logger():
             if len(self.available_indices) > 0:
 
                 try:
-                    LV = self._create_log_var(name, samples_per_sec, var_type)
+                    lv = self._create_log_var(name, samples_per_sec, var_type)
                 except Exception as e:
                     print(e)
                 else:
                     #send command to AMDC
-                    cmd = f'log reg {LV.index} {LV.name} {LV.memory_addr} {LV.samples_per_sec} {LV.var_type}'
+                    cmd = f'log reg {lv.index} {lv.name} {lv.memory_addr} {lv.samples_per_sec} {lv.var_type}'
                     out = self.amdc.cmd(cmd)
                     if out[1] == 'FAILURE':
-                        self._pop(LV)
+                        self._pop(lv)
 
             else:
                 print(
@@ -118,11 +118,11 @@ class AMDC_Logger():
 
         for var in variables:
             try:
-                LV = self._pop(var)
+                lv = self._pop(var)
             except:
                 print('ERROR: Invalid variable name')
             else:
-                self.amdc.cmd(f'log unreg {LV.index}')
+                self.amdc.cmd(f'log unreg {lv.index}')
 
     def unregister_all(self):
 
@@ -312,14 +312,14 @@ class AMDC_Logger():
                     idx = self.available_indices.pop(loc)
 
                 #create LogVar object and append it to logvars
-                LV = LogVar(name=name,
+                lv = LogVar(name=name,
                             index=idx,
                             var_type=var_type,
                             samples_per_sec=samples_per_sec,
                             memory_addr=memory_addr)
-                self.log_vars[name] = LV
+                self.log_vars[name] = lv
 
-                return LV
+                return lv
 
             else:
                 raise Exception('Error: Variable already exists')
@@ -328,18 +328,18 @@ class AMDC_Logger():
 
         if log_var in self.log_vars.keys():
 
-            LV = self.log_vars.pop(log_var)
-            self.available_indices.append(LV.index)
+            lv = self.log_vars.pop(log_var)
+            self.available_indices.append(lv.index)
             self.available_indices.sort(reverse=True)
-            return LV
+            return lv
 
     def _dump_single_bin(self, var, print_output=True):
         # Function level debugging (for print statements)
         debug = False
 
         var = self._sanitize_inputs(var)[0]
-        LV = self.log_vars[var]
-        log_var_idx = LV.index
+        lv = self.log_vars[var]
+        log_var_idx = lv.index
 
         # Don't automatically capture binary output data!
         old_state_captureOutput = self.amdc.captureOutput
@@ -524,8 +524,8 @@ class AMDC_Logger():
     def _dump_single_text(self, var):
 
         var = self._sanitize_inputs(var)[0]
-        LV = self.log_vars[var]
-        log_var_idx = LV.index
+        lv = self.log_vars[var]
+        log_var_idx = lv.index
 
         #we want to set the print state to false so we don't
         #print all of our data to the screen

--- a/scripts/AMDC_Logger.py
+++ b/scripts/AMDC_Logger.py
@@ -1,4 +1,5 @@
 import time
+from collections import namedtuple
 import numpy as np
 import pandas as pd
 import pathlib as pl
@@ -13,6 +14,8 @@ import binascii
 # Date:        06/30/2020
 #########################################################
 
+LogVar = namedtuple(typename = 'LogVar', field_names = 'name index var_type samples_per_sec memmory_addr')
+
 class AMDC_Logger():
     
     default_max_slots = 32
@@ -23,8 +26,7 @@ class AMDC_Logger():
         self.mapfile = Mapfile(mapfile)
         
         self.available_indices = list(range(AMDC_Logger.default_max_slots))[-1::-1]
-        self.log_vars = []
-        self.log_var_indices = []
+        self.log_vars = {}
         
     def info(self):
         max_slots, names, types, indices, sample_rates, num_samples = self._get_amdc_state()
@@ -54,14 +56,9 @@ class AMDC_Logger():
         self._reset()
         
         #we don't actually register the variables because they are already registered
-        for var, idx in zip(names, indices):
-            self.log_vars.append(var)
-            self.log_var_indices.append(idx)
+        for var, idx, tp, sps in zip(names, indices):
+            self._create_log_var(name = var, samples_per_sec = sps, var_type = tp, manual_index = idx)
             
-            #remove index from list of available indices
-            loc = self.available_indices.index(idx)
-            self.available_indices.pop(loc)
-        
     def register(self, log_vars, samples_per_sec = 1000, var_type = 'double'):
         
         names = self._sanitize_inputs(log_vars)
@@ -70,25 +67,21 @@ class AMDC_Logger():
             
             if len(self.available_indices) > 0:
                 
-                memory_addr = int(self.mapfile.address(name), 0)
-                
-                if memory_addr == 0:
-                    print(f"ERROR: couldn't find memory address for '{name}'")
-                
+                try:
+                    LV = self._create_log_var(name, samples_per_sec, var_type)
+                except:
+                    pass
                 else:
-                    if not (name in self.log_vars):
-                        self.log_vars.append(name)
-                        idx = self.available_indices.pop() #extract next available index
-                        self.log_var_indices.append(idx)
-                        cmd = f'log reg {idx} {name} {memory_addr} {samples_per_sec} {var_type}'
-                        out = self.amdc.cmd(cmd)
-                        if out[1] == 'FAILURE':
-                            self.unregister(name, send_cmd = False)
+                    #send command to AMDC
+                    cmd = f'log reg {LV.index} {LV.name} {LV.memory_addr} {LV.samples_per_sec} {LV.var_type}'
+                    out = self.amdc.cmd(cmd)
+                    if out[1] == 'FAILURE':
+                        self._pop(LV)
             
             else:
                 print(f'Did not register, cannot exceed maximum of {self.max_slots} logged variables')
                 print(f'Logged variables are:\n{self.log_vars}')
-                
+            
     def auto_register(self, root, samples_per_sec = 1000):
         
         #provide path to root of C code for which you want the logger to search for variables
@@ -108,31 +101,31 @@ class AMDC_Logger():
         
         for var in variables:
             try:
-                loc = self.log_vars.index(var) #find location of var in list of vars
+                LV = self._pop(var)
             except:
                 print('ERROR: Invalid variable name')
             else:
-                self.log_vars.pop(loc)
-                idx = self.log_var_indices.pop(loc)
-                self.available_indices.append(idx)
-                self.available_indices.sort(reverse = True)
-                
-                if send_cmd:
-                    self.amdc.cmd(f'log unreg {idx}')
+                self.amdc.cmd(f'log unreg {LV.index}')
     
     def unregister_all(self):
         
         #we have to put log_vars into a local variable because self.log_vars changes
         #as we iterate over it
-        variables = self.log_vars.copy()
+        variables = list(self.log_vars.keys())
         
         for var in variables:
             self.unregister(var)    
                 
-    def clear(self, var):
+    def clear(self, log_vars):
         
-        log_var_idx = self._get_index(var)
-        self.amdc.cmd(f'log empty {log_var_idx}')
+        variables = self._sanitize_inputs(log_vars)
+        
+        for var in variables:
+            try:
+                log_var_idx = self.log_vars[var].index
+                self.amdc.cmd(f'log empty {log_var_idx}')
+            except:
+                pass
         
     def clear_all(self):
         
@@ -179,7 +172,7 @@ class AMDC_Logger():
         if log_vars is not None:
             variables = self._sanitize_inputs(log_vars)
         else:
-            variables = self.log_vars
+            variables = self.log_vars.keys()
             
         binary = 0
         
@@ -196,7 +189,7 @@ class AMDC_Logger():
         if len(variables) > 0:
             for i, var in enumerate(variables):
                 
-                if var in self.log_vars:
+                if var in self.log_vars.keys():
                     
                     #try multiple times to load data if it fails
                     while tries < max_tries:
@@ -265,13 +258,49 @@ class AMDC_Logger():
         out = pd.read_csv(p, comment = '#', index_col = 't')
         
         return out
+    
+    def _create_log_var(self, name, samples_per_sec, var_type, manual_index = None):
+        
+        memory_addr = int(self.mapfile.address(name), 0)
+        
+        if memory_addr == 0:
+            raise Exception(f"ERROR: couldn't find memory address for '{name}'")
+            
+        else:
+            if name not in self.log_vars.keys(): #check if variable name already registered
+
+                if manual_index is None:
+                    idx = self.available_indices.pop() #extract next available index
+                else:
+                    #remove index from list of available indices
+                    loc = self.available_indices.index(manual_index)
+                    idx = self.available_indices.pop(loc)
+                
+                #create LogVar object and append it to logvars
+                LV = LogVar(name = name, index = idx, var_type = var_type, samples_per_sec = samples_per_sec, memory_addr = memory_addr)
+                self.log_vars[name] = LV
+                
+                return LV
+            
+            else:
+                raise Exception('Error: Variable already exists')
+            
+    def _pop(self, log_var):
+        
+        if log_var in self.log_vars.keys():
+            
+            LV = self.log_vars.pop(log_var)
+            self.available_indices.append(LV.index)
+            self.available_indices.sort(reverse = True)
+            return LV
         
     def _dump_single_bin(self, var, print_output = True):
         # Function level debugging (for print statements)
         debug = False
         
         var = self._sanitize_inputs(var)[0]
-        log_var_idx = self._get_index(var)
+        LV = self.log_vars[var]
+        log_var_idx = LV.index
         
         # Don't automatically capture binary output data! 
         old_state_captureOutput = self.amdc.captureOutput
@@ -440,7 +469,8 @@ class AMDC_Logger():
     def _dump_single_text(self, var):
         
         var = self._sanitize_inputs(var)[0]
-        log_var_idx = self._get_index(var)
+        LV = self.log_vars[var]
+        log_var_idx = LV.index
         
         #we want to set the print state to false so we don't
         #print all of our data to the screen
@@ -485,21 +515,10 @@ class AMDC_Logger():
 
         return df
     
-    def _get_index(self, var):
-        
-        try:
-            loc = self.log_vars.index(var) #find location of var in list of vars
-        except:
-            raise Exception('ERROR: Invalid variable name')
-        else:
-            log_var_idx = self.log_var_indices[loc] #use location to get 
-            return log_var_idx
-    
     def _reset(self):
         
         self.available_indices = list(range(self.max_slots))[-1::-1]
-        self.log_vars = []
-        self.log_var_indices = []      
+        self.log_vars = {}
             
     @staticmethod   
     def _process_line(line):

--- a/scripts/AMDC_Logger.py
+++ b/scripts/AMDC_Logger.py
@@ -14,7 +14,7 @@ import binascii
 # Date:        06/30/2020
 #########################################################
 
-LogVar = namedtuple(typename = 'LogVar', field_names = 'name index var_type samples_per_sec memmory_addr')
+LogVar = namedtuple(typename = 'LogVar', field_names = 'name index var_type samples_per_sec memory_addr')
 
 class AMDC_Logger():
     
@@ -56,7 +56,7 @@ class AMDC_Logger():
         self._reset()
         
         #we don't actually register the variables because they are already registered
-        for var, idx, tp, sps in zip(names, indices):
+        for var, idx, tp, sps in zip(names, indices, types, sample_rates):
             self._create_log_var(name = var, samples_per_sec = sps, var_type = tp, manual_index = idx)
             
     def register(self, log_vars, samples_per_sec = 1000, var_type = 'double'):
@@ -69,8 +69,8 @@ class AMDC_Logger():
                 
                 try:
                     LV = self._create_log_var(name, samples_per_sec, var_type)
-                except:
-                    pass
+                except Exception as e:
+                    print(e)
                 else:
                     #send command to AMDC
                     cmd = f'log reg {LV.index} {LV.name} {LV.memory_addr} {LV.samples_per_sec} {LV.var_type}'

--- a/scripts/AMDC_Logger.py
+++ b/scripts/AMDC_Logger.py
@@ -14,59 +14,72 @@ import binascii
 # Date:        06/30/2020
 #########################################################
 
-LogVar = namedtuple(typename = 'LogVar', field_names = 'name index var_type samples_per_sec memory_addr')
+LogVar = namedtuple(
+    typename='LogVar',
+    field_names='name index var_type samples_per_sec memory_addr')
+
 
 class AMDC_Logger():
-    
+
     default_max_slots = 32
-    
+
     def __init__(self, AMDC, mapfile):
-        
+
         self.amdc = AMDC
         self.mapfile = Mapfile(mapfile)
-        
-        self.available_indices = list(range(AMDC_Logger.default_max_slots))[-1::-1]
+
+        self.available_indices = list(range(
+            AMDC_Logger.default_max_slots))[-1::-1]
         self.log_vars = {}
-        
+
     def info(self):
-        max_slots, names, types, indices, sample_rates, num_samples = self._get_amdc_state()
-        
+        max_slots, names, types, indices, sample_rates, num_samples = self._get_amdc_state(
+        )
+
         N = 15
-        
+
         title = 'AMDC LOGGER INFO'.center(22).center(60, '#') + '\n\n'
-        header = 'Variable Name:'.ljust(N) + 'Index:'.center(N) + 'Type:'.center(N) + 'Sample Rate [Hz]:'.center(N + 10) + 'Number of Samples:'
-        
+        header = 'Variable Name:'.ljust(N) + 'Index:'.center(
+            N) + 'Type:'.center(N) + 'Sample Rate [Hz]:'.center(
+                N + 10) + 'Number of Samples:'
+
         print(title + header)
-        
-        for (var, idx, t, sps, samples) in zip(names, indices, types, sample_rates, num_samples):
-            line = f'{var}'.ljust(N) + f'{idx}'.center(N) + f'{t}'.center(N) + f'{sps}'.center(N + 10) + f'{samples}'.center(N)
+
+        for (var, idx, t, sps, samples) in zip(names, indices, types,
+                                               sample_rates, num_samples):
+            line = f'{var}'.ljust(N) + f'{idx}'.center(N) + f'{t}'.center(
+                N) + f'{sps}'.center(N + 10) + f'{samples}'.center(N)
             print(line)
 
         # Add extra new line
         print()
 
     def sync(self):
-        
+
         #the AMDC is the source of truth so calling sync will synchronize python
         #with the amdc. this is useful if the python kernel is restarted
-        
-        max_slots, names, types, indices, sample_rates, num_samples = self._get_amdc_state()
+
+        max_slots, names, types, indices, sample_rates, num_samples = self._get_amdc_state(
+        )
         self.max_slots = max_slots
 
         self._reset()
-        
+
         #we don't actually register the variables because they are already registered
         for var, idx, tp, sps in zip(names, indices, types, sample_rates):
-            self._create_log_var(name = var, samples_per_sec = sps, var_type = tp, manual_index = idx)
-            
-    def register(self, log_vars, samples_per_sec = 1000, var_type = 'double'):
-        
+            self._create_log_var(name=var,
+                                 samples_per_sec=sps,
+                                 var_type=tp,
+                                 manual_index=idx)
+
+    def register(self, log_vars, samples_per_sec=1000, var_type='double'):
+
         names = self._sanitize_inputs(log_vars)
-        
+
         for name in names:
-            
+
             if len(self.available_indices) > 0:
-                
+
                 try:
                     LV = self._create_log_var(name, samples_per_sec, var_type)
                 except Exception as e:
@@ -77,28 +90,32 @@ class AMDC_Logger():
                     out = self.amdc.cmd(cmd)
                     if out[1] == 'FAILURE':
                         self._pop(LV)
-            
+
             else:
-                print(f'Did not register, cannot exceed maximum of {self.max_slots} logged variables')
+                print(
+                    f'Did not register, cannot exceed maximum of {self.max_slots} logged variables'
+                )
                 print(f'Logged variables are:\n{self.log_vars}')
-            
-    def auto_register(self, root, samples_per_sec = 1000):
-        
+
+    def auto_register(self, root, samples_per_sec=1000):
+
         #provide path to root of C code for which you want the logger to search for variables
         #of the form `LOG_{var_name}`
-               
+
         log_vars, log_types = self.auto_find_vars(root)
-        
+
         print(f'Total Number of Variables to be Logged: {len(log_vars)}')
-        
+
         #register all found variables
         for var, tp in zip(log_vars, log_types):
-            self.register(log_vars = var, samples_per_sec = samples_per_sec, var_type = tp)
-                
-    def unregister(self, log_vars, send_cmd = True):
-        
+            self.register(log_vars=var,
+                          samples_per_sec=samples_per_sec,
+                          var_type=tp)
+
+    def unregister(self, log_vars, send_cmd=True):
+
         variables = self._sanitize_inputs(log_vars)
-        
+
         for var in variables:
             try:
                 LV = self._pop(var)
@@ -106,37 +123,37 @@ class AMDC_Logger():
                 print('ERROR: Invalid variable name')
             else:
                 self.amdc.cmd(f'log unreg {LV.index}')
-    
+
     def unregister_all(self):
-        
+
         #we have to put log_vars into a local variable because self.log_vars changes
         #as we iterate over it
         variables = list(self.log_vars.keys())
-        
+
         for var in variables:
-            self.unregister(var)    
-                
+            self.unregister(var)
+
     def clear(self, log_vars):
-        
+
         variables = self._sanitize_inputs(log_vars)
-        
+
         for var in variables:
             try:
                 log_var_idx = self.log_vars[var].index
                 self.amdc.cmd(f'log empty {log_var_idx}')
             except:
                 pass
-        
+
     def clear_all(self):
-        
+
         for var in self.log_vars:
             self.clear(var)
-        
+
     def auto_find_vars(self, root):
-        
+
         log_vars = []
         log_types = []
-        
+
         #extract all valid logging variables
         for path, dirs, files in os.walk(root):
             for file in files:
@@ -146,176 +163,198 @@ class AMDC_Logger():
                     for var, tp in zip(lv, lt):
                         log_vars.append(var)
                         log_types.append(tp)
-                        
+
         return log_vars, log_types
-        
+
     def start(self):
         self.amdc.cmd('log start')
-        
+
     def stop(self):
         self.amdc.cmd('log stop')
-        
-    def log(self, duration = 0.25):
-        
-        old_delay = self.amdc.cmdDelay #store old time delay
-        self.amdc.cmdDelay = 0.01 #temporarily set delay between commands to shorter
-        
+
+    def log(self, duration=0.25):
+
+        old_delay = self.amdc.cmdDelay  #store old time delay
+        self.amdc.cmdDelay = 0.01  #temporarily set delay between commands to shorter
+
         self.start()
         time.sleep(duration)
         self.stop()
-        
-        self.amdc.cmdDelay = old_delay #reset cmd delay to previous value
-        
-        
-    def dump(self, log_vars = None, file = None, comment = '', timestamp = True, timestamp_fmt = '%Y-%m-%d_H%H-M%M-S%S', how = 'binary', max_tries = 4, print_output = True):
-              
+
+        self.amdc.cmdDelay = old_delay  #reset cmd delay to previous value
+
+    def dump(self,
+             log_vars=None,
+             file=None,
+             comment='',
+             timestamp=True,
+             timestamp_fmt='%Y-%m-%d_H%H-M%M-S%S',
+             how='binary',
+             max_tries=4,
+             print_output=True):
+
         if log_vars is not None:
             variables = self._sanitize_inputs(log_vars)
         else:
             variables = self.log_vars.keys()
-            
+
         binary = 0
-        
+
         if how.lower() == 'ascii':
             dump_func = self._dump_single_text
         elif how.lower() == 'binary':
             binary = 1
             dump_func = self._dump_single_bin
         else:
-            raise Exception("Invalid type of dump, valid types are: 'binary' or 'ascii'")
-        
+            raise Exception(
+                "Invalid type of dump, valid types are: 'binary' or 'ascii'")
+
         tries = 0
-        
+
         if len(variables) > 0:
             for i, var in enumerate(variables):
-                
+
                 if var in self.log_vars.keys():
-                    
+
                     #try multiple times to load data if it fails
                     while tries < max_tries:
                         try:
                             if binary:
-                                df_new = dump_func(var, print_output = print_output)
+                                df_new = dump_func(var,
+                                                   print_output=print_output)
                             else:
                                 df_new = dump_func(var)
-                                
+
                         except Exception as e:
                             print(e)
-                            
+
                             tries += 1
                             if tries < max_tries:
                                 print(f'failed loading {var}... retrying\n')
                         else:
-                            
+
                             if i == 0:
                                 df = df_new
                             else:
-                                df = df.join(df_new, how = 'outer')
-                                
+                                df = df.join(df_new, how='outer')
+
                             tries = 0
                             break
-                    
+
                     if tries > 0:
                         raise Exception('Loading Data Failed')
 
             if file != None:
-                
+
                 #ensure that file is pathlib path
                 file = pl.Path(file)
                 p = file.parent
-                
+
                 if not p.exists():
                     p.mkdir()
-                
+
                 if timestamp:
-                    path = p / (file.stem + '_' + datetime.datetime.now().strftime(timestamp_fmt) + '.csv')
+                    path = p / (file.stem + '_' +
+                                datetime.datetime.now().strftime(timestamp_fmt)
+                                + '.csv')
                 else:
                     path = p / (file.stem + '.csv')
-                    
+
                 if len(comment) > 0:
-                    
+
                     if comment[0] != '#':
                         comment = '#' + comment
                     if comment[-1] != '\n':
                         comment += '\n'
-                        
-                    with open(path, 'a', newline = '') as f:
+
+                    with open(path, 'a', newline='') as f:
                         f.write(comment)
                         df.to_csv(f)
-                else:            
+                else:
                     df.to_csv(path)
-                    
+
             return df
-        
+
         else:
             return None
-        
+
     def load(self, file):
-        
+
         p = pl.Path(file)
         p = p.parent / (p.stem + '.csv')
-        
-        out = pd.read_csv(p, comment = '#', index_col = 't')
-        
+
+        out = pd.read_csv(p, comment='#', index_col='t')
+
         return out
-    
-    def _create_log_var(self, name, samples_per_sec, var_type, manual_index = None):
-        
+
+    def _create_log_var(self,
+                        name,
+                        samples_per_sec,
+                        var_type,
+                        manual_index=None):
+
         memory_addr = int(self.mapfile.address(name), 0)
-        
+
         if memory_addr == 0:
-            raise Exception(f"ERROR: couldn't find memory address for '{name}'")
-            
+            raise Exception(
+                f"ERROR: couldn't find memory address for '{name}'")
+
         else:
-            if name not in self.log_vars.keys(): #check if variable name already registered
+            if name not in self.log_vars.keys(
+            ):  #check if variable name already registered
 
                 if manual_index is None:
-                    idx = self.available_indices.pop() #extract next available index
+                    idx = self.available_indices.pop(
+                    )  #extract next available index
                 else:
                     #remove index from list of available indices
                     loc = self.available_indices.index(manual_index)
                     idx = self.available_indices.pop(loc)
-                
+
                 #create LogVar object and append it to logvars
-                LV = LogVar(name = name, index = idx, var_type = var_type, samples_per_sec = samples_per_sec, memory_addr = memory_addr)
+                LV = LogVar(name=name,
+                            index=idx,
+                            var_type=var_type,
+                            samples_per_sec=samples_per_sec,
+                            memory_addr=memory_addr)
                 self.log_vars[name] = LV
-                
+
                 return LV
-            
+
             else:
                 raise Exception('Error: Variable already exists')
-            
+
     def _pop(self, log_var):
-        
+
         if log_var in self.log_vars.keys():
-            
+
             LV = self.log_vars.pop(log_var)
             self.available_indices.append(LV.index)
-            self.available_indices.sort(reverse = True)
+            self.available_indices.sort(reverse=True)
             return LV
-        
-    def _dump_single_bin(self, var, print_output = True):
+
+    def _dump_single_bin(self, var, print_output=True):
         # Function level debugging (for print statements)
         debug = False
-        
+
         var = self._sanitize_inputs(var)[0]
         LV = self.log_vars[var]
         log_var_idx = LV.index
-        
-        # Don't automatically capture binary output data! 
+
+        # Don't automatically capture binary output data!
         old_state_captureOutput = self.amdc.captureOutput
         old_state_cmdDelay = self.amdc.cmdDelay
         self.amdc.captureOutput = False
         self.amdc.cmdDelay = 0.010
 
         start_time = time.time()
-        timeout_sec = 55 # dump is at 2kSPS, so this could wait for max 110k samples
+        timeout_sec = 55  # dump is at 2kSPS, so this could wait for max 110k samples
 
         # Start dumping to host
-        self.amdc.cmd(f"log dump bin {log_var_idx}") 
+        self.amdc.cmd(f"log dump bin {log_var_idx}")
         if print_output:
             print("Dumping:", var)
-        
+
         # Reset the previous state
         self.amdc.captureOutput = old_state_captureOutput
         self.amdc.old_state_cmdDelay = old_state_cmdDelay
@@ -342,15 +381,19 @@ class AMDC_Logger():
             dump_data_max += N
             dump_data_idx = 0
 
-            s = struct.Struct('<IIII')    
+            s = struct.Struct('<IIII')
 
-            for i in range(0,dump_data_max-s.size):
-                magic = s.unpack(dump_data[i:i+s.size])
+            for i in range(0, dump_data_max - s.size):
+                magic = s.unpack(dump_data[i:i + s.size])
 
-                if magic[0] == MAGIC_HEADER and magic[1] == MAGIC_HEADER and magic[2] == MAGIC_HEADER and magic[3] == MAGIC_HEADER:
+                if magic[0] == MAGIC_HEADER and magic[
+                        1] == MAGIC_HEADER and magic[
+                            2] == MAGIC_HEADER and magic[3] == MAGIC_HEADER:
                     magic_header_idx = dump_data_idx
 
-                if magic[0] == MAGIC_FOOTER and magic[1] == MAGIC_FOOTER and magic[2] == MAGIC_FOOTER and magic[3] == MAGIC_FOOTER:
+                if magic[0] == MAGIC_FOOTER and magic[
+                        1] == MAGIC_FOOTER and magic[
+                            2] == MAGIC_FOOTER and magic[3] == MAGIC_FOOTER:
                     magic_footer_idx = dump_data_idx
                     found_footer = True
                     break
@@ -372,35 +415,43 @@ class AMDC_Logger():
         # This might be unnessecary; at minimum, we might need to do this
         # one time to get the CRC bytes from the AMDC since they come after
         # the footer bytes.
-        for i in range(0,10):
+        for i in range(0, 10):
             out = bytes(self.amdc.ser.read_all())
             dump_data += out
 
         if debug:
-            print("DEBUG:", "all data:", binascii.hexlify(bytearray(dump_data)), len(dump_data))
+            print("DEBUG:", "all data:",
+                  binascii.hexlify(bytearray(dump_data)), len(dump_data))
 
         if debug:
             print("DEBUG:", "magic_header_idx:", magic_header_idx)
             print("DEBUG:", "magic_footer_idx:", magic_footer_idx)
 
-            foot_data = dump_data[magic_footer_idx:magic_footer_idx+16]
-            print("DEBUG:", "FOOTER:", binascii.hexlify(bytearray(foot_data)), len(foot_data))
+            foot_data = dump_data[magic_footer_idx:magic_footer_idx + 16]
+            print("DEBUG:", "FOOTER:", binascii.hexlify(bytearray(foot_data)),
+                  len(foot_data))
 
         # Calculate CRC-32 over data we got and make sure it is valid!
-        crc_data = dump_data[magic_header_idx:magic_footer_idx+16]
+        crc_data = dump_data[magic_header_idx:magic_footer_idx + 16]
 
         if debug:
             print("DEBUG:", "full data length:", len(crc_data))
-            print("DEBUG:", "HEADER:", binascii.hexlify(bytearray(crc_data[0:16])))
-            print("DEBUG:", "full data:", binascii.hexlify(bytearray(dump_data[magic_header_idx:magic_footer_idx+16+4])))
+            print("DEBUG:", "HEADER:",
+                  binascii.hexlify(bytearray(crc_data[0:16])))
+            print(
+                "DEBUG:", "full data:",
+                binascii.hexlify(
+                    bytearray(dump_data[magic_header_idx:magic_footer_idx +
+                                        16 + 4])))
 
         crc_calculated_python = binascii.crc32(crc_data, 0) & 0xffffffff
 
         if debug:
-            print("DEBUG:", "crc_calculated_python:", hex(crc_calculated_python))
+            print("DEBUG:", "crc_calculated_python:",
+                  hex(crc_calculated_python))
 
         # Extract the CRC that the AMDC sent
-        crc_from_amdc = dump_data[magic_footer_idx+16:magic_footer_idx+20]
+        crc_from_amdc = dump_data[magic_footer_idx + 16:magic_footer_idx + 20]
         crc_from_amdc = struct.unpack('<I', crc_from_amdc)[0]
 
         if debug:
@@ -408,27 +459,31 @@ class AMDC_Logger():
 
         # Check to make AMDC CRC matches Python CRC
         if crc_calculated_python != crc_from_amdc:
-            raise Exception("ERROR: CRC doesn't match:", hex(crc_calculated_python), hex(crc_from_amdc))
+            raise Exception("ERROR: CRC doesn't match:",
+                            hex(crc_calculated_python), hex(crc_from_amdc))
 
         N = len(dump_data)
         bout = bytes(dump_data)
 
-        metadata_start_idx = magic_header_idx+(4*4)
+        metadata_start_idx = magic_header_idx + (4 * 4)
 
         s = struct.Struct("<III")
-        unpacked_header      = s.unpack(bout[metadata_start_idx:metadata_start_idx+s.size])
-        num_samples          = unpacked_header[0]
+        unpacked_header = s.unpack(bout[metadata_start_idx:metadata_start_idx +
+                                        s.size])
+        num_samples = unpacked_header[0]
         sample_interval_usec = unpacked_header[1]
-        data_type            = unpacked_header[2]
+        data_type = unpacked_header[2]
 
         if print_output:
             print("Dump took:", '{:.3f}'.format(end_time - start_time), " sec")
-            print("Dump rate:", '{:.3f}'.format(num_samples / (end_time - start_time)), " sps")
+            print("Dump rate:",
+                  '{:.3f}'.format(num_samples / (end_time - start_time)),
+                  " sps")
 
         if debug:
             print("DEBUG:", "data type:", hex(data_type), data_type)
 
-        dump_samples_idx = metadata_start_idx+s.size
+        dump_samples_idx = metadata_start_idx + s.size
 
         if data_type == 1:
             s = struct.Struct('<i')
@@ -440,52 +495,52 @@ class AMDC_Logger():
         samples = []
         time_sec = 0
 
-        for i in range(0,num_samples):   
-            sample = s.unpack(bout[dump_samples_idx:dump_samples_idx+s.size])
+        for i in range(0, num_samples):
+            sample = s.unpack(bout[dump_samples_idx:dump_samples_idx + s.size])
             dump_samples_idx += s.size
 
-            ts  = time_sec
+            ts = time_sec
             val = sample[0]
 
             samples.append([ts, val])
 
             time_sec += sample_interval_usec / 1e6
 
-        if print_output:        
+        if print_output:
             print("Num samples:", num_samples, "\n")
 
         # Convert to DataFrame
         arr = np.array(samples)
 
         # Round all timesteps to nearest 1usec
-        arr[:,0] = arr[:,0].round(6)
+        arr[:, 0] = arr[:, 0].round(6)
 
-        df = pd.DataFrame(data = arr, columns = ['t', var[4::]])
+        df = pd.DataFrame(data=arr, columns=['t', var[4::]])
         df['t'] = df['t'] - df['t'].min()
-        df.set_index('t', inplace = True)
+        df.set_index('t', inplace=True)
 
         return df
-        
+
     def _dump_single_text(self, var):
-        
+
         var = self._sanitize_inputs(var)[0]
         LV = self.log_vars[var]
         log_var_idx = LV.index
-        
+
         #we want to set the print state to false so we don't
         #print all of our data to the screen
         old_state = self.amdc.printOutput
         self.amdc.printOutput = False
-        
+
         self.amdc.cmd(f"log dump text {log_var_idx}")
-        
+
         samples = []
-        
+
         line = ""
         while True:
             c = self.amdc.ser.read().decode()
             line += c
-            
+
             if ("\n" in c):
                 try:
                     sample = self._process_line(line)
@@ -499,31 +554,31 @@ class AMDC_Logger():
                     # Flush the rest of the RX line
                     for j in range(10000):
                         self.amdc.ser.read()
-                    
+
                     # End the outer for loop
                     break
-            
+
                 line = ""
 
         arr = np.array(samples)
-        df = pd.DataFrame(data = arr, columns = ['t', var[4::]])
+        df = pd.DataFrame(data=arr, columns=['t', var[4::]])
         df['t'] = df['t'] - df['t'].min()
-        
-        df.set_index('t', inplace = True)
-        
-        self.amdc.printOutput = old_state #reset the print state
+
+        df.set_index('t', inplace=True)
+
+        self.amdc.printOutput = old_state  #reset the print state
 
         return df
-    
+
     def _reset(self):
-        
+
         self.available_indices = list(range(self.max_slots))[-1::-1]
         self.log_vars = {}
-            
-    @staticmethod   
+
+    @staticmethod
     def _process_line(line):
         colline = ' '.join(line.split())
-        
+
         # Don't process empty lines
         if (len(colline) == 0):
             raise Exception()
@@ -534,102 +589,103 @@ class AMDC_Logger():
 
         args = colline.split(' ')
 
-        ts  = float(int(args[1])) / 1e6
-        v   = float(args[2])
+        ts = float(int(args[1])) / 1e6
+        v = float(args[2])
 
         if (ts != 0.0):
             return [ts, v]
-        
+
         raise Exception()
-        
+
     @staticmethod
     def _sanitize_inputs(names):
-        
+
         valid = [list, tuple]
-        
+
         if type(names) in valid:
             pass
         else:
             names = names.split()
-            
+
         out = []
-            
+
         for name in names:
             if not ('LOG_' in name):
                 name = 'LOG_' + name
-            
+
             out.append(name)
-            
+
         return out
-    
+
     @staticmethod
     def _find_log_vars(file):
-        
+
         valid_types = 'int double float char'.split()
         log_vars = []
         log_types = []
-        
+
         with open(file) as f:
-            
+
             for line in f:
                 if 'LOG_' in line:
                     lst = line.split()
                     if lst[0] in valid_types:
                         log_types.append(lst[0])
                         log_vars.append(lst[1])
-            
+
         return log_vars, log_types
-        
+
     def _get_amdc_state(self):
-        
+
         old_state = self.amdc.printOutput
         self.amdc.printOutput = False
-        
+
         oldDelay = self.amdc.cmdDelay
         self.amdc.cmdDelay = 0.5
-        
+
         out = self.amdc.cmd('log info')
         self.amdc.printOutput = old_state
 
         max_slots = int(out[4].split()[-1])
-        
+
         names = []
         types = []
         indices = []
         sample_rates = []
         num_samples = []
-        
+
         slot = 0
-        
+
         for line in out:
-            
+
             if ('Slot' in line) and ('unused' not in line):
                 indices.append(slot)
                 slot += 1
-                
+
             if ('Slot' in line) and ('unused' in line):
                 slot += 1
-            
+
             if 'Name' in line:
                 names.append(line.split()[-1])
-                
+
             if 'Type' in line:
                 types.append(line.split()[-1])
-                
+
             if 'Sampling' in line:
-                sample_rates.append(1 / ((int(line.split()[-1]))/1e6))
-                
+                sample_rates.append(1 / ((int(line.split()[-1])) / 1e6))
+
             if 'Num samples' in line:
                 num_samples.append(int(line.split()[-1]))
-                
+
         self.amdc.cmdDelay = oldDelay
-                
+
         return max_slots, names, types, indices, sample_rates, num_samples
-        
+
+
 def find_mapfile(root):
-    
+
     f = 'mapfile.txt'
-    
+
     p = None
 
     for path, dirs, files in os.walk(root):
@@ -640,42 +696,43 @@ def find_mapfile(root):
 
 
 class Mapfile:
-    
     def __init__(self, filepath):
-        
+
         self.filepath = filepath
 
     def address(self, var_name):
-        
+
         with open(self.filepath, 'r') as fp:
             line = fp.readline()
-            
+
             while line:
                 colline = ' '.join(line.split())
-                
+
                 # Don't process empty lines
                 if len(colline) == 0:
                     line = fp.readline()
                     continue
-                
+
                 tokens = colline.split(' ')
-                
+
                 # Only process lines which could be of interest
                 if len(tokens) != 2:
                     line = fp.readline()
                     continue
-                
+
                 # Check if we are at the line of interest
                 if tokens[1] == var_name:
                     return tokens[0]
                     break
-                
+
                 line = fp.readline()
-                
+
             return "0x0"
-        
+
+
 def main():
-    
-    pass    
+
+    pass
+
 
 if __name__ == '__main__': main()

--- a/scripts/format_code.py
+++ b/scripts/format_code.py
@@ -3,6 +3,8 @@ import pathlib as pl
 
 path = pl.Path('.')
 
+py_files_to_ignore = ['format_code', 'run-clang-format']
+
 #loop over all python files and format the files in place
 for file in path.iterdir():
     if file.suffix == '.py' and file.stem != 'format_code':

--- a/scripts/format_code.py
+++ b/scripts/format_code.py
@@ -1,0 +1,9 @@
+from yapf.yapflib.yapf_api import FormatFile
+import pathlib as pl
+
+path = pl.Path('.')
+
+#loop over all python files and format the files in place
+for file in path.iterdir():
+    if file.suffix == '.py' and file.stem != 'format_code':
+        FormatFile(str(file), style_config='pep8', in_place = True)

--- a/scripts/format_code.py
+++ b/scripts/format_code.py
@@ -6,4 +6,4 @@ path = pl.Path('.')
 #loop over all python files and format the files in place
 for file in path.iterdir():
     if file.suffix == '.py' and file.stem != 'format_code':
-        FormatFile(str(file), style_config='pep8', in_place = True)
+        FormatFile(str(file), style_config='setup.cfg', in_place = True)

--- a/scripts/run-clang-format.py
+++ b/scripts/run-clang-format.py
@@ -30,7 +30,6 @@ try:
 except ImportError:
     DEVNULL = open(os.devnull, "wb")
 
-
 DEFAULT_EXTENSIONS = 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'
 DEFAULT_CLANG_FORMAT_IGNORE = '.clang-format-ignore'
 
@@ -39,6 +38,7 @@ class ExitStatus:
     SUCCESS = 0
     DIFF = 1
     TROUBLE = 2
+
 
 def excludes_from_file(ignore_file):
     excludes = []
@@ -56,7 +56,8 @@ def excludes_from_file(ignore_file):
     except EnvironmentError as e:
         if e.errno != errno.ENOENT:
             raise
-    return excludes;
+    return excludes
+
 
 def list_files(files, recursive=False, extensions=None, exclude=None):
     if extensions is None:
@@ -74,8 +75,7 @@ def list_files(files, recursive=False, extensions=None, exclude=None):
                     # by modifying it in-place,
                     # to avoid unnecessary directory listings.
                     dnames[:] = [
-                        x for x in dnames
-                        if
+                        x for x in dnames if
                         not fnmatch.fnmatch(os.path.join(dirpath, x), pattern)
                     ]
                     fpaths = [
@@ -92,12 +92,11 @@ def list_files(files, recursive=False, extensions=None, exclude=None):
 
 def make_diff(file, original, reformatted):
     return list(
-        difflib.unified_diff(
-            original,
-            reformatted,
-            fromfile='{}\t(original)'.format(file),
-            tofile='{}\t(reformatted)'.format(file),
-            n=3))
+        difflib.unified_diff(original,
+                             reformatted,
+                             fromfile='{}\t(original)'.format(file),
+                             tofile='{}\t(reformatted)'.format(file),
+                             n=3))
 
 
 class DiffError(Exception):
@@ -120,8 +119,8 @@ def run_clang_format_diff_wrapper(args, file):
     except DiffError:
         raise
     except Exception as e:
-        raise UnexpectedError('{}: {}: {}'.format(file, e.__class__.__name__,
-                                                  e), e)
+        raise UnexpectedError(
+            '{}: {}: {}'.format(file, e.__class__.__name__, e), e)
 
 
 def run_clang_format_diff(args, file):
@@ -155,18 +154,14 @@ def run_clang_format_diff(args, file):
         encoding_py3['encoding'] = 'utf-8'
 
     try:
-        proc = subprocess.Popen(
-            invocation,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
-            **encoding_py3)
+        proc = subprocess.Popen(invocation,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                universal_newlines=True,
+                                **encoding_py3)
     except OSError as exc:
-        raise DiffError(
-            "Command '{}' failed to start: {}".format(
-                subprocess.list2cmdline(invocation), exc
-            )
-        )
+        raise DiffError("Command '{}' failed to start: {}".format(
+            subprocess.list2cmdline(invocation), exc))
     proc_stdout = proc.stdout
     proc_stderr = proc.stderr
     if sys.version_info[0] < 3:
@@ -182,8 +177,7 @@ def run_clang_format_diff(args, file):
     if proc.returncode:
         raise DiffError(
             "Command '{}' returned non-zero exit status {}".format(
-                subprocess.list2cmdline(invocation), proc.returncode
-            ),
+                subprocess.list2cmdline(invocation), proc.returncode),
             errs,
         )
     return make_diff(file, original, outs), errs
@@ -237,39 +231,34 @@ def print_trouble(prog, message, use_colors):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        '--clang-format-executable',
-        metavar='EXECUTABLE',
-        help='path to the clang-format executable',
-        default='clang-format')
+    parser.add_argument('--clang-format-executable',
+                        metavar='EXECUTABLE',
+                        help='path to the clang-format executable',
+                        default='clang-format')
     parser.add_argument(
         '--extensions',
         help='comma separated list of file extensions (default: {})'.format(
             DEFAULT_EXTENSIONS),
         default=DEFAULT_EXTENSIONS)
-    parser.add_argument(
-        '-r',
-        '--recursive',
-        action='store_true',
-        help='run recursively over directories')
+    parser.add_argument('-r',
+                        '--recursive',
+                        action='store_true',
+                        help='run recursively over directories')
     parser.add_argument('files', metavar='file', nargs='+')
-    parser.add_argument(
-        '-q',
-        '--quiet',
-        action='store_true',
-        help="disable output, useful for the exit code")
-    parser.add_argument(
-        '-j',
-        metavar='N',
-        type=int,
-        default=0,
-        help='run N clang-format jobs in parallel'
-        ' (default number of cpus + 1)')
-    parser.add_argument(
-        '--color',
-        default='auto',
-        choices=['auto', 'always', 'never'],
-        help='show colored diff (default: auto)')
+    parser.add_argument('-q',
+                        '--quiet',
+                        action='store_true',
+                        help="disable output, useful for the exit code")
+    parser.add_argument('-j',
+                        metavar='N',
+                        type=int,
+                        default=0,
+                        help='run N clang-format jobs in parallel'
+                        ' (default number of cpus + 1)')
+    parser.add_argument('--color',
+                        default='auto',
+                        choices=['auto', 'always', 'never'],
+                        help='show colored diff (default: auto)')
     parser.add_argument(
         '-e',
         '--exclude',
@@ -311,8 +300,7 @@ def main():
         print_trouble(
             parser.prog,
             "Command '{}' failed to start: {}".format(
-                subprocess.list2cmdline(version_invocation), e
-            ),
+                subprocess.list2cmdline(version_invocation), e),
             use_colors=colored_stderr,
         )
         return ExitStatus.TROUBLE
@@ -322,11 +310,10 @@ def main():
     excludes = excludes_from_file(DEFAULT_CLANG_FORMAT_IGNORE)
     excludes.extend(args.exclude)
 
-    files = list_files(
-        args.files,
-        recursive=args.recursive,
-        exclude=excludes,
-        extensions=args.extensions.split(','))
+    files = list_files(args.files,
+                       recursive=args.recursive,
+                       exclude=excludes,
+                       extensions=args.extensions.split(','))
 
     if not files:
         return
@@ -343,8 +330,8 @@ def main():
         pool = None
     else:
         pool = multiprocessing.Pool(njobs)
-        it = pool.imap_unordered(
-            partial(run_clang_format_diff_wrapper, args), files)
+        it = pool.imap_unordered(partial(run_clang_format_diff_wrapper, args),
+                                 files)
     while True:
         try:
             outs, errs = next(it)

--- a/scripts/setup.cfg
+++ b/scripts/setup.cfg
@@ -1,0 +1,3 @@
+[yapf]
+based_on_style = pep8
+#column_limit = 85


### PR DESCRIPTION
I've restructured the way python stores logging variables to used named tuples. This method should be much more extensible than the previous way of doing it. Note that the user interface for logging has not changed at all.
