### PR TITLE
Move defines to appropriate location

### DIFF
--- a/sdk/bare/common/sys/commands.h
+++ b/sdk/bare/common/sys/commands.h
@@ -6,6 +6,14 @@
 #define COMMANDS_UPDATES_PER_SEC (10000)
 #define COMMANDS_INTERVAL_USEC   (USEC_IN_SEC / COMMANDS_UPDATES_PER_SEC)
 
+// Supported command handler return codes
+#define CMD_SUCCESS           (0)
+#define CMD_FAILURE           (1)
+#define CMD_SUCCESS_QUIET     (2)
+#define CMD_INVALID_ARGUMENTS (3)
+#define CMD_INPUT_TOO_LONG    (4)
+#define CMD_UNKNOWN_CMD       (5)
+
 // Forward declarations
 typedef struct command_entry_t command_entry_t;
 typedef struct command_help_t command_help_t;

--- a/sdk/bare/common/sys/commands.h
+++ b/sdk/bare/common/sys/commands.h
@@ -1,7 +1,7 @@
 #ifndef COMMANDS_H
 #define COMMANDS_H
 
-#include "sys/defines.h"
+#include "sys/scheduler.h"
 
 #define COMMANDS_UPDATES_PER_SEC (10000)
 #define COMMANDS_INTERVAL_USEC   (USEC_IN_SEC / COMMANDS_UPDATES_PER_SEC)

--- a/sdk/bare/common/sys/defines.h
+++ b/sdk/bare/common/sys/defines.h
@@ -14,13 +14,6 @@
     printf("HANG!!!\n");                                                                                               \
     while (1)
 
-#define CMD_SUCCESS           (0)
-#define CMD_FAILURE           (1)
-#define CMD_SUCCESS_QUIET     (2)
-#define CMD_INVALID_ARGUMENTS (3)
-#define CMD_INPUT_TOO_LONG    (4)
-#define CMD_UNKNOWN_CMD       (5)
-
 #define SUCCESS (0)
 #define FAILURE (1)
 

--- a/sdk/bare/common/sys/defines.h
+++ b/sdk/bare/common/sys/defines.h
@@ -5,11 +5,6 @@
 
 #define UNUSED(x) (void) (x)
 
-#define USEC_IN_SEC (1000000)
-
-#define SEC_TO_USEC(sec)  (sec * USEC_IN_SEC)
-#define USEC_TO_SEC(usec) (usec / USEC_IN_SEC)
-
 #define HANG                                                                                                           \
     printf("HANG!!!\n");                                                                                               \
     while (1)

--- a/sdk/bare/common/sys/scheduler.h
+++ b/sdk/bare/common/sys/scheduler.h
@@ -8,6 +8,11 @@
 #include "sys/task_stats.h"
 #include "usr/user_config.h"
 
+// Utility defines for time conversions
+#define USEC_IN_SEC (1000000)
+#define SEC_TO_USEC(sec)  (sec * USEC_IN_SEC)
+#define USEC_TO_SEC(usec) (usec / USEC_IN_SEC)
+
 // SysTick
 //
 // The basic time quantum is defined to be SYS_TICK_FREQ.

--- a/sdk/bare/common/sys/scheduler.h
+++ b/sdk/bare/common/sys/scheduler.h
@@ -9,7 +9,7 @@
 #include "usr/user_config.h"
 
 // Utility defines for time conversions
-#define USEC_IN_SEC (1000000)
+#define USEC_IN_SEC       (1000000)
 #define SEC_TO_USEC(sec)  (sec * USEC_IN_SEC)
 #define USEC_TO_SEC(usec) (usec / USEC_IN_SEC)
 

--- a/sdk/bare/common/sys/serial.h
+++ b/sdk/bare/common/sys/serial.h
@@ -1,7 +1,7 @@
 #ifndef SERIAL_H
 #define SERIAL_H
 
-#include "sys/defines.h"
+#include "sys/scheduler.h"
 
 #define SERIAL_UPDATES_PER_SEC (10000)
 #define SERIAL_INTERVAL_USEC   (USEC_IN_SEC / SERIAL_UPDATES_PER_SEC)

--- a/sdk/bare/common/sys/task_stats.c
+++ b/sdk/bare/common/sys/task_stats.c
@@ -85,7 +85,7 @@ typedef struct sm_ctx_t {
 #define SM_UPDATES_PER_SEC (200)
 #define SM_INTERVAL_USEC   (USEC_IN_SEC / SM_UPDATES_PER_SEC)
 
-void state_machine_callback(void *arg)
+static void state_machine_callback(void *arg)
 {
     sm_ctx_t *ctx = (sm_ctx_t *) arg;
 

--- a/sdk/bare/common/usr/demo/task_cc.h
+++ b/sdk/bare/common/usr/demo/task_cc.h
@@ -1,7 +1,7 @@
 #ifndef TASK_CC_H
 #define TASK_CC_H
 
-#include "sys/defines.h"
+#include "sys/scheduler.h"
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/sdk/bare/user/usr/beta_labs/task_dtc.h
+++ b/sdk/bare/user/usr/beta_labs/task_dtc.h
@@ -2,7 +2,7 @@
 #define TASK_DTC_H
 
 #include "drv/analog.h"
-#include "sys/defines.h"
+#include "sys/scheduler.h"
 #include <stdint.h>
 
 #define TASK_DTC_UPDATES_PER_SEC (10000)

--- a/sdk/bare/user/usr/beta_labs/task_mc.h
+++ b/sdk/bare/user/usr/beta_labs/task_mc.h
@@ -1,7 +1,7 @@
 #ifndef TASK_MC_H
 #define TASK_MC_H
 
-#include "sys/defines.h"
+#include "sys/scheduler.h"
 #include <stdint.h>
 
 #define TASK_MC_UPDATES_PER_SEC (4000)

--- a/sdk/bare/user/usr/beta_labs/task_mo.h
+++ b/sdk/bare/user/usr/beta_labs/task_mo.h
@@ -1,7 +1,7 @@
 #ifndef TASK_MO_H
 #define TASK_MO_H
 
-#include "sys/defines.h"
+#include "sys/scheduler.h"
 
 #define TASK_MO_UPDATES_PER_SEC (10000)
 #define TASK_MO_INTERVAL_USEC   (USEC_IN_SEC / TASK_MO_UPDATES_PER_SEC)

--- a/sdk/bare/user/usr/beta_labs/task_vsi.h
+++ b/sdk/bare/user/usr/beta_labs/task_vsi.h
@@ -1,7 +1,7 @@
 #ifndef TASK_VSI_H
 #define TASK_VSI_H
 
-#include "sys/defines.h"
+#include "sys/scheduler.h"
 #include <stdint.h>
 
 #define TASK_VSI_UPDATES_PER_SEC (10000)

--- a/sdk/bare/user/usr/blink/task_blink.h
+++ b/sdk/bare/user/usr/blink/task_blink.h
@@ -1,7 +1,7 @@
 #ifndef TASK_BLINK_H
 #define TASK_BLINK_H
 
-#include "sys/defines.h"
+#include "sys/scheduler.h"
 
 // Frequency that this task is called (in Hz)
 //

--- a/sdk/bare/user/usr/blink/task_vsi.h
+++ b/sdk/bare/user/usr/blink/task_vsi.h
@@ -1,7 +1,7 @@
 #ifndef TASK_VSI_H
 #define TASK_VSI_H
 
-#include "sys/defines.h"
+#include "sys/scheduler.h"
 
 #define TASK_VSI_UPDATES_PER_SEC (10000)
 #define TASK_VSI_INTERVAL_USEC   (USEC_IN_SEC / TASK_VSI_UPDATES_PER_SEC)


### PR DESCRIPTION
This PR tries to minimize the number of things defined in `sys/defines.h` since this is such a generic filename and not very descriptive. Most of the items can be moved to a specific header file...