### PR TITLE
Update user config to support changing logging max variables + sample depth

### DIFF
--- a/sdk/bare/common/sys/cmd/cmd_log.c
+++ b/sdk/bare/common/sys/cmd/cmd_log.c
@@ -46,7 +46,7 @@ int cmd_log(int argc, char **argv)
 
         // Parse arg1: log_var_idx
         int log_var_idx = atoi(argv[2]);
-        if (log_var_idx >= LOG_MAX_NUM_VARS || log_var_idx < 0) {
+        if (log_var_idx >= LOG_MAX_NUM_VARIABLES || log_var_idx < 0) {
             // ERROR
             return CMD_INVALID_ARGUMENTS;
         }
@@ -94,7 +94,7 @@ int cmd_log(int argc, char **argv)
 
         // Parse log_var_idx arg
         int log_var_idx = atoi(argv[2]);
-        if (log_var_idx >= LOG_MAX_NUM_VARS || log_var_idx < 0) {
+        if (log_var_idx >= LOG_MAX_NUM_VARIABLES || log_var_idx < 0) {
             // ERROR
             return CMD_INVALID_ARGUMENTS;
         }
@@ -148,7 +148,7 @@ int cmd_log(int argc, char **argv)
 
         // Parse log_var_idx
         int log_var_idx = atoi(argv[3]);
-        if (log_var_idx >= LOG_MAX_NUM_VARS || log_var_idx < 0) {
+        if (log_var_idx >= LOG_MAX_NUM_VARIABLES || log_var_idx < 0) {
             // ERROR
             return CMD_INVALID_ARGUMENTS;
         }
@@ -180,7 +180,7 @@ int cmd_log(int argc, char **argv)
 
         // Parse arg1: log_var_idx
         int log_var_idx = atoi(argv[2]);
-        if (log_var_idx >= LOG_MAX_NUM_VARS || log_var_idx < 0) {
+        if (log_var_idx >= LOG_MAX_NUM_VARIABLES || log_var_idx < 0) {
             // ERROR
             return CMD_INVALID_ARGUMENTS;
         }

--- a/sdk/bare/user/usr/user_config.h
+++ b/sdk/bare/user/usr/user_config.h
@@ -3,13 +3,13 @@
 
 #include "drv/hardware_targets.h"
 
-// This file is used to override system defines.
+// This file is used to override system defines and conditionally enable
+// various system-level firmware features.
 
 // Specify hardware revision (i.e. REV C, REV D, etc)
-#define USER_CONFIG_HARDWARE_TARGET AMDC_REV_C
+#define USER_CONFIG_HARDWARE_TARGET (AMDC_REV_C)
 
-// Override the default scheduler elementary
-// frequency by defining SYS_TICK_FREQ here.
+// Override the default scheduler elementary frequency by defining SYS_TICK_FREQ here.
 // System uses 10kHz by default
 //#define SYS_TICK_FREQ (20000) // Hz
 
@@ -29,6 +29,14 @@
 // Enable logging functionality
 // set to 1 for enabled, 0 for disabled
 #define USER_CONFIG_ENABLE_LOGGING (0)
+
+// Override default number of available logging variables
+// when defined, this takes precedence over system default of 32
+//#define USER_CONFIG_LOGGING_MAX_NUM_VARIABLES (150)
+
+// Override default logging sample depth per variable
+// when defined, this takes precedence over system default of 100k
+//#define USER_CONFIG_LOGGING_SAMPLE_DEPTH_PER_VARIABLE (50000)
 
 // Enable injection functionality
 // set to 1 for enabled, 0 for disabled


### PR DESCRIPTION
This PR updates the logging system to allow user configuration of max sampling depth and max logging variables via the `usr/user_config.h` file. By default, this PR does not change the system functionality -- it just gives the user the ability to change system defines.

The `sys/log.h` module checks the specified values to make sure they will fit in memory / meet timing requirements.

## Integration

This PR does not change system functionality by default. To change the logging sample depth or max slots, edit your `usr/user_config.h` file (for example, 3 slots with 1M sample depth):

```C
// Enable logging functionality
// set to 1 for enabled, 0 for disabled
#define USER_CONFIG_ENABLE_LOGGING (1)

// Override default number of available logging variables
// when defined, this takes precedence over system default of 32
#define USER_CONFIG_LOGGING_MAX_NUM_VARIABLES (3)

// Override default logging sample depth per variable
// when defined, this takes precedence over system default of 100k
#define USER_CONFIG_LOGGING_SAMPLE_DEPTH_PER_VARIABLE (1000000)
```

The user is free to select any values they want for the above defines. The system will throw compiler errors if the values are unreasonable and not supported. This limits memory usage and makes the code meet timing.


## Experimental Validation

I have logged the 3 default `task_vsi` variables on my REV D AMDC with the logging system configured in various sample depth / max slots options...

### Max slots

I set the max slots to 150 (the max supported) and it worked fine. I only logged ~4k samples, and with no controllers running. The python code works fine with >32 slots (it gets the correct value from the `log info` command)

Note: there is some significant nuance here.... you would think that the system would support arbitrarily large max number of slots... i.e. if I configure each slot to sample depth of 1k, I should be able to log thousands of variables. However, with the current architecture, this is not true. This is VERY in the weeds, but I believe the issue is cache misses due to LARGE memory access stride patterns, thus causing full memory reads from external RAM for each logging variable. With 100s of logging variables, these extra latencies add up, thus causing the logging task to miss timing and overrun the time quantum. I am currently limiting the max number of slots to 150. This seems to work well.

### Large sample depth

I set the sample depth to 1M and logged at 10kHz for 100 seconds. Dumping the `task_vsi` vars over UART took about 8 min each (at 2ksps)... Very slow, but it worked! I updated the python code to change the timeout for dumping based on the max sample depth.

![image](https://user-images.githubusercontent.com/20168990/89693451-1aa66400-d8d4-11ea-9a42-411232f1ee13.png)


## Related Issues

- Closes: #148