### PR TITLE
Update injection engine commands to accept floats

### DIFF
--- a/sdk/bare/common/sys/cmd/cmd_inj.c
+++ b/sdk/bare/common/sys/cmd/cmd_inj.c
@@ -15,10 +15,10 @@ static command_entry_t cmd_entry;
 static command_help_t cmd_help[] = {
     { "clear", "Clear all injections" },
     { "list", "List all available injection points" },
-    { "const <name> <set|add|sub> <mValue>", "Inject a constant" },
-    { "noise <name> <set|add|sub> <mGain> <mOffset>", "Inject noise" },
-    { "chirp <name> <set|add|sub> <mGain> <mFreqMin> <mFreqMax> <mPeriod>", "Inject chirp" },
-    { "triangle <name> <set|add|sub> <mValueMin> <mValueMax> <mPeriod>", "Inject triangle" },
+    { "const <name> <set|add|sub> <value>", "Inject a constant" },
+    { "noise <name> <set|add|sub> <gain> <offset>", "Inject noise" },
+    { "chirp <name> <set|add|sub> <gain> <freqMin> <freqMax> <period>", "Inject chirp" },
+    { "triangle <name> <set|add|sub> <valueMin> <valueMax> <period>", "Inject triangle" },
 };
 
 void cmd_inj_register(void)
@@ -32,13 +32,13 @@ void cmd_inj_register(void)
 
 static int _parse_op(char *op_str, inj_op_e *inj_op)
 {
-    if (strcmp("set", op_str) == 0) {
+    if (STREQ("set", op_str)) {
         *inj_op = SET;
         return 0;
-    } else if (strcmp("add", op_str) == 0) {
+    } else if (STREQ("add", op_str)) {
         *inj_op = ADD;
         return 0;
-    } else if (strcmp("sub", op_str) == 0) {
+    } else if (STREQ("sub", op_str)) {
         *inj_op = SUB;
         return 0;
     }
@@ -49,19 +49,19 @@ static int _parse_op(char *op_str, inj_op_e *inj_op)
 int cmd_inj(int argc, char **argv)
 {
     // Handle 'inj clear' command
-    if (argc == 2 && strcmp("clear", argv[1]) == 0) {
+    if (argc == 2 && STREQ("clear", argv[1])) {
         injection_clear();
         return CMD_SUCCESS;
     }
 
     // Handle 'inj list' command
-    if (argc == 2 && strcmp("list", argv[1]) == 0) {
+    if (argc == 2 && STREQ("list", argv[1])) {
         injection_list();
         return CMD_SUCCESS;
     }
 
     // Handle 'inj const ...' command
-    if (argc == 5 && strcmp("const", argv[1]) == 0) {
+    if (argc == 5 && STREQ("const", argv[1])) {
         // Parse out name and convert to injection context
         inj_ctx_t *ctx = injection_find_ctx_by_name(argv[2]);
         if (ctx == NULL)
@@ -72,21 +72,19 @@ int cmd_inj(int argc, char **argv)
         if (_parse_op(argv[3], &op) != 0)
             return CMD_INVALID_ARGUMENTS;
 
-        // Pull out mValue argument
+        // Pull out value argument
         // and saturate to -10 .. 10
-        double mValue = (double) atoi(argv[5]);
-        if (mValue < -10000.0)
-            return CMD_INVALID_ARGUMENTS;
-        if (mValue > 10000.0)
+        double value = strtod(argv[5], NULL);
+        if (value < -10.0 || value > 10.0)
             return CMD_INVALID_ARGUMENTS;
 
-        injection_const(ctx, op, mValue / 1000.0);
+        injection_const(ctx, op, value);
 
         return CMD_SUCCESS;
     }
 
     // Handle 'inj noise ...' command
-    if (argc == 6 && strcmp("noise", argv[1]) == 0) {
+    if (argc == 6 && STREQ("noise", argv[1])) {
         // Parse out name and convert to injection context
         inj_ctx_t *ctx = injection_find_ctx_by_name(argv[2]);
         if (ctx == NULL)
@@ -97,29 +95,25 @@ int cmd_inj(int argc, char **argv)
         if (_parse_op(argv[3], &op) != 0)
             return CMD_INVALID_ARGUMENTS;
 
-        // Pull out mGain argument
+        // Pull out gain argument
         // and saturate to 0 .. 50
-        double mGain = (double) atoi(argv[4]);
-        if (mGain < 0.0)
-            return CMD_INVALID_ARGUMENTS;
-        if (mGain > 50000.0)
+        double gain = strtod(argv[4], NULL);
+        if (gain < 0.0 || gain > 50.0)
             return CMD_INVALID_ARGUMENTS;
 
-        // Pull out mOffset argument
+        // Pull out offset argument
         // and saturate to -100 .. 100
-        double mOffset = (double) atoi(argv[5]);
-        if (mOffset < -100000.0)
-            return CMD_INVALID_ARGUMENTS;
-        if (mOffset > 100000.0)
+        double offset = strtod(argv[5], NULL);
+        if (offset < -100.0 || offset > 100.0)
             return CMD_INVALID_ARGUMENTS;
 
-        injection_noise(ctx, op, mGain / 1000.0, mOffset / 1000.0);
+        injection_noise(ctx, op, gain, offset);
 
         return CMD_SUCCESS;
     }
 
     // Handle 'inj chirp ...' command
-    if (argc == 8 && strcmp("chirp", argv[1]) == 0) {
+    if (argc == 8 && STREQ("chirp", argv[1])) {
         // Parse out name and convert to injection context
         inj_ctx_t *ctx = injection_find_ctx_by_name(argv[2]);
         if (ctx == NULL)
@@ -130,45 +124,37 @@ int cmd_inj(int argc, char **argv)
         if (_parse_op(argv[3], &op) != 0)
             return CMD_INVALID_ARGUMENTS;
 
-        // Pull out mGain argument
+        // Pull out gain argument
         // and saturate to 0 .. 10
-        double mGain = (double) atoi(argv[4]);
-        if (mGain < 0.0)
-            return CMD_INVALID_ARGUMENTS;
-        if (mGain > 10000.0)
+        double gain = strtod(argv[4], NULL);
+        if (gain < 0.0 || gain > 10.0)
             return CMD_INVALID_ARGUMENTS;
 
-        // Pull out mFreqMin argument
+        // Pull out freqMin argument
         // and saturate to 0 .. 10000Hz
-        double mFreqMin = (double) atoi(argv[5]);
-        if (mFreqMin < 0.0)
-            return CMD_INVALID_ARGUMENTS;
-        if (mFreqMin > 10000000.0)
+        double freqMin = strtod(argv[5], NULL);
+        if (freqMin < 0.0 || freqMin > 10000.0)
             return CMD_INVALID_ARGUMENTS;
 
-        // Pull out mFreqMax argument
+        // Pull out freqMax argument
         // and saturate to 0 .. 10000Hz
-        double mFreqMax = (double) atoi(argv[6]);
-        if (mFreqMax < 0.0)
-            return CMD_INVALID_ARGUMENTS;
-        if (mFreqMax > 10000000.0)
+        double freqMax = strtod(argv[5], NULL);
+        if (freqMax < 0.0 || freqMax > 10000.0)
             return CMD_INVALID_ARGUMENTS;
 
-        // Pull out mPeriod argument
-        // and saturate to 1 .. 60 sec
-        double mPeriod = (double) atoi(argv[7]);
-        if (mPeriod < 1000.0)
-            return CMD_INVALID_ARGUMENTS;
-        if (mPeriod > 60000.0)
+        // Pull out period argument
+        // and saturate to 10ms .. 60 sec
+        double period = strtod(argv[7], NULL);
+        if (period < 0.010 || period > 60.0)
             return CMD_INVALID_ARGUMENTS;
 
-        injection_chirp(ctx, op, mGain / 1000.0, mFreqMin / 1000.0, mFreqMax / 1000.0, mPeriod / 1000.0);
+        injection_chirp(ctx, op, gain, freqMin, freqMax, period);
 
         return CMD_SUCCESS;
     }
 
     // Handle 'inj triangle ...' command
-    if (argc == 7 && strcmp("triangle", argv[1]) == 0) {
+    if (argc == 7 && STREQ("triangle", argv[1])) {
         // Parse out name and convert to injection context
         inj_ctx_t *ctx = injection_find_ctx_by_name(argv[2]);
         if (ctx == NULL)
@@ -179,31 +165,25 @@ int cmd_inj(int argc, char **argv)
         if (_parse_op(argv[3], &op) != 0)
             return CMD_INVALID_ARGUMENTS;
 
-        // Pull out mValueMin argument
+        // Pull out valueMin argument
         // and saturate to -100 .. 100
-        double mValueMin = (double) atoi(argv[4]);
-        if (mValueMin < -100000.0)
-            return CMD_INVALID_ARGUMENTS;
-        if (mValueMin > 100000.0)
+        double valueMin = strtod(argv[4], NULL);
+        if (valueMin < -100.0 || valueMin > 100.0)
             return CMD_INVALID_ARGUMENTS;
 
-        // Pull out mValueMax argument
+        // Pull out valueMax argument
         // and saturate to -100 .. 100
-        double mValueMax = (double) atoi(argv[5]);
-        if (mValueMax < -100000.0)
-            return CMD_INVALID_ARGUMENTS;
-        if (mValueMax > 100000.0)
+        double valueMax = strtod(argv[5], NULL);
+        if (valueMax < -100.0 || valueMax > 100.0)
             return CMD_INVALID_ARGUMENTS;
 
-        // Pull out mPeriod argument
-        // and saturate to 1 .. 60 sec
-        double mPeriod = (double) atoi(argv[6]);
-        if (mPeriod < 1000.0)
-            return CMD_INVALID_ARGUMENTS;
-        if (mPeriod > 60000.0)
+        // Pull out period argument
+        // and saturate to 10ms .. 60 sec
+        double period = strtod(argv[6], NULL);
+        if (period < 0.010 || period > 60.0)
             return CMD_INVALID_ARGUMENTS;
 
-        injection_triangle(ctx, op, mValueMin / 1000.0, mValueMax / 1000.0, mPeriod / 1000.0);
+        injection_triangle(ctx, op, valueMin, valueMax, period);
 
         return CMD_SUCCESS;
     }


### PR DESCRIPTION
This PR updates the `inj` command interface (via CLI). Now, the user can specify values as floating point numbers (such as `3.14`). Previously, they had to be integers and the code divided them by 1000 (i.e. the user entered "milli" values).

This doesn't change the system capabilities, but it may alter people's scripts that were using the injection engine (they'll need to enter the actual values, not 1000x the values).

Example: `inj noise Id* set 0.010 1` would inject noise into the injection point called "Id*" with 0.010 of gain and an offset of 1.

## Related Issues

- Closes: #160 