### PR TITLE
Increase max chars to 24 per command argument

### DIFF
--- a/sdk/bare/common/sys/commands.c
+++ b/sdk/bare/common/sys/commands.c
@@ -17,7 +17,7 @@ static char recv_buffer[RECV_BUFFER_LENGTH] = { 0 };
 static int recv_buffer_idx = 0;
 
 #define CMD_MAX_ARGC       (16) // # of args accepted
-#define CMD_MAX_ARG_LENGTH (16) // max chars of any arg
+#define CMD_MAX_ARG_LENGTH (24) // max chars of any arg
 typedef struct pending_cmd_t {
     int argc;
     char *argv[CMD_MAX_ARGC];

--- a/sdk/bare/common/sys/injection.h
+++ b/sdk/bare/common/sys/injection.h
@@ -39,7 +39,7 @@ typedef struct inj_func_triangle_t {
     double period;
 } inj_func_triangle_t;
 
-#define INJ_MAX_NAME_LENGTH (16)
+#define INJ_MAX_NAME_LENGTH (24)
 
 typedef struct inj_ctx_t {
     int id;


### PR DESCRIPTION
This is a minor PR which allows longer command argument length.

i.e.
```
cmd this is an argumentandisverylong
```