### PR TITLE
Issue/transformation matrix

### DIFF
--- a/sdk/bare/common/sys/transform.c
+++ b/sdk/bare/common/sys/transform.c
@@ -47,7 +47,7 @@ void transform_clarke_inverse(transform_dqz_type_e C, double *abc, double *xyz)
 void transform_park_inverse(double theta, double *xyz, double *dqz)
 {
     // Rotate backwards
-    transform_park(-theta, xyz, dqz);
+    transform_park(-theta, dqz, xyz);
 }
 
 void transform_dqz_inverse(transform_dqz_type_e C, double theta, double *abc, double *dqz)
@@ -56,3 +56,4 @@ void transform_dqz_inverse(transform_dqz_type_e C, double theta, double *abc, do
     transform_park_inverse(theta, xyz, dqz);
     transform_clarke_inverse(C, abc, xyz);
 }
+

--- a/sdk/bare/common/sys/transform.c
+++ b/sdk/bare/common/sys/transform.c
@@ -4,16 +4,16 @@
 
 void transform_clarke(transform_dqz_type_e C, double *abc, double *xyz)
 {
-	if (C == TRANS_DQZ_C_INVARIANT_AMPLITUDE) {
-		xyz[0] = C_INVARIANT_AMPLITUDE * (1 * abc[0] - 0.5 * abc[1] - 0.5 * abc[2]);
-    	xyz[1] = C_INVARIANT_AMPLITUDE * (0 * abc[0] + SQRT3 / 2 * abc[1] - SQRT3 / 2 * abc[2]);
-    	xyz[2] = (1 / 3 * abc[0] + 1 / 3 * abc[1] + 1 / 3 * abc[2]);
-	}
+    if (C == TRANS_DQZ_C_INVARIANT_AMPLITUDE) {
+        xyz[0] = C_INVARIANT_AMPLITUDE * (1 * abc[0] - 0.5 * abc[1] - 0.5 * abc[2]);
+        xyz[1] = C_INVARIANT_AMPLITUDE * (0 * abc[0] + SQRT3 / 2 * abc[1] - SQRT3 / 2 * abc[2]);
+        xyz[2] = (1 / 3 * abc[0] + 1 / 3 * abc[1] + 1 / 3 * abc[2]);
+    }
     if (C == TRANS_DQZ_C_INVARIANT_POWER) {
-		xyz[0] = C_INVARIANT_POWER * (1 * abc[0] - 0.5 * abc[1] - 0.5 * abc[2]);
-    	xyz[1] = C_INVARIANT_POWER * (0 * abc[0] + SQRT3 / 2 * abc[1] - SQRT3 / 2 * abc[2]);
-		xyz[2] = (1 / SQRT3 * abc[0] + 1 / SQRT3 * abc[1] + 1 / SQRT3 * abc[2]);
-	}
+        xyz[0] = C_INVARIANT_POWER * (1 * abc[0] - 0.5 * abc[1] - 0.5 * abc[2]);
+        xyz[1] = C_INVARIANT_POWER * (0 * abc[0] + SQRT3 / 2 * abc[1] - SQRT3 / 2 * abc[2]);
+        xyz[2] = (1 / SQRT3 * abc[0] + 1 / SQRT3 * abc[1] + 1 / SQRT3 * abc[2]);
+    }
 }
 
 void transform_park(double theta, double *xyz, double *dqz)
@@ -32,22 +32,22 @@ void transform_dqz(transform_dqz_type_e C, double theta, double *abc, double *dq
 
 void transform_clarke_inverse(transform_dqz_type_e C, double *abc, double *xyz)
 {
-	if (C == TRANS_DQZ_C_INVARIANT_AMPLITUDE) {
-		abc[0] = 1 * xyz[0] + 0 * xyz[1] + xyz[2];
-		abc[1] = -1 / 2 * xyz[0] + SQRT3 / 2 * xyz[1] + xyz[2];
-		abc[2] = -1 / 2 * xyz[0] - SQRT3 / 2 * xyz[1] + xyz[2];
-	}
-	if (C == TRANS_DQZ_C_INVARIANT_POWER) {
-		abc[0] = C_INVARIANT_POWER * (1 * xyz[0] + 0 * xyz[1] + 1 / SQRT2 * xyz[2]);
-		abc[1] = C_INVARIANT_POWER * (-1 / 2 * xyz[0] + SQRT3 / 2 * xyz[1] + 1 / SQRT2 * xyz[2]);
-		abc[2] = C_INVARIANT_POWER * (-1 / 2 * xyz[0] - SQRT3 / 2 * xyz[1] + 1 / SQRT2 * xyz[2]);
-	}
+    if (C == TRANS_DQZ_C_INVARIANT_AMPLITUDE) {
+        abc[0] = 1 * xyz[0] + 0 * xyz[1] + xyz[2];
+        abc[1] = -1 / 2 * xyz[0] + SQRT3 / 2 * xyz[1] + xyz[2];
+        abc[2] = -1 / 2 * xyz[0] - SQRT3 / 2 * xyz[1] + xyz[2];
+    }
+    if (C == TRANS_DQZ_C_INVARIANT_POWER) {
+        abc[0] = C_INVARIANT_POWER * (1 * xyz[0] + 0 * xyz[1] + 1 / SQRT2 * xyz[2]);
+        abc[1] = C_INVARIANT_POWER * (-1 / 2 * xyz[0] + SQRT3 / 2 * xyz[1] + 1 / SQRT2 * xyz[2]);
+        abc[2] = C_INVARIANT_POWER * (-1 / 2 * xyz[0] - SQRT3 / 2 * xyz[1] + 1 / SQRT2 * xyz[2]);
+    }
 }
 
 void transform_park_inverse(double theta, double *xyz, double *dqz)
 {
-	// Rotate backwards
-	transform_park(-theta, xyz, dqz);
+    // Rotate backwards
+    transform_park(-theta, xyz, dqz);
 }
 
 void transform_dqz_inverse(transform_dqz_type_e C, double theta, double *abc, double *dqz)

--- a/sdk/bare/common/sys/transform.c
+++ b/sdk/bare/common/sys/transform.c
@@ -2,14 +2,16 @@
 #include "defines.h"
 #include <math.h>
 
-void transform_clarke(double C, double *abc, double *xyz)
+void transform_clarke(transform_dqz_type_e C, double *abc, double *xyz)
 {
-    xyz[0] = C * (1 * abc[0] - 0.5 * abc[1] - 0.5 * abc[2]);
-    xyz[1] = C * (0 * abc[0] + SQRT3 / 2 * abc[1] - SQRT3 / 2 * abc[2]);
-    if (C == TRANS_DQZ_C_INVARIANT_AMPLITUDE) {
+	if (C == TRANS_DQZ_C_INVARIANT_AMPLITUDE) {
+		xyz[0] = C_INVARIANT_AMPLITUDE * (1 * abc[0] - 0.5 * abc[1] - 0.5 * abc[2]);
+    	xyz[1] = C_INVARIANT_AMPLITUDE * (0 * abc[0] + SQRT3 / 2 * abc[1] - SQRT3 / 2 * abc[2]);
     	xyz[2] = (1 / 3 * abc[0] + 1 / 3 * abc[1] + 1 / 3 * abc[2]);
 	}
     if (C == TRANS_DQZ_C_INVARIANT_POWER) {
+		xyz[0] = C_INVARIANT_POWER * (1 * abc[0] - 0.5 * abc[1] - 0.5 * abc[2]);
+    	xyz[1] = C_INVARIANT_POWER * (0 * abc[0] + SQRT3 / 2 * abc[1] - SQRT3 / 2 * abc[2]);
 		xyz[2] = (1 / SQRT3 * abc[0] + 1 / SQRT3 * abc[1] + 1 / SQRT3 * abc[2]);
 	}
 }
@@ -21,14 +23,14 @@ void transform_park(double theta, double *xyz, double *dqz)
     dqz[2] = +0 * xyz[0] + 0 * xyz[1] + 1 * xyz[2];
 }
 
-void transform_dqz(double C, double theta, double *abc, double *dqz)
+void transform_dqz(transform_dqz_type_e C, double theta, double *abc, double *dqz)
 {
     double xyz[3];
     transform_clarke(C, abc, xyz);
     transform_park(theta, xyz, dqz);
 }
 
-void transform_clarke_inverse(double C, double *abc, double *xyz)
+void transform_clarke_inverse(transform_dqz_type_e C, double *abc, double *xyz)
 {
 	if (C == TRANS_DQZ_C_INVARIANT_AMPLITUDE) {
 		abc[0] = 1 * xyz[0] + 0 * xyz[1] + xyz[2];
@@ -36,9 +38,9 @@ void transform_clarke_inverse(double C, double *abc, double *xyz)
 		abc[2] = -1 / 2 * xyz[0] - SQRT3 / 2 * xyz[1] + xyz[2];
 	}
 	if (C == TRANS_DQZ_C_INVARIANT_POWER) {
-		abc[0] = C * (1 * xyz[0] + 0 * xyz[1] + 1 / SQRT2 * xyz[2]);
-		abc[1] = C * (-1 / 2 * xyz[0] + SQRT3 / 2 * xyz[1] + 1 / SQRT2 * xyz[2]);
-		abc[2] = C * (-1 / 2 * xyz[0] - SQRT3 / 2 * xyz[1] + 1 / SQRT2 * xyz[2]);
+		abc[0] = C_INVARIANT_POWER * (1 * xyz[0] + 0 * xyz[1] + 1 / SQRT2 * xyz[2]);
+		abc[1] = C_INVARIANT_POWER * (-1 / 2 * xyz[0] + SQRT3 / 2 * xyz[1] + 1 / SQRT2 * xyz[2]);
+		abc[2] = C_INVARIANT_POWER * (-1 / 2 * xyz[0] - SQRT3 / 2 * xyz[1] + 1 / SQRT2 * xyz[2]);
 	}
 }
 
@@ -48,7 +50,7 @@ void transform_park_inverse(double theta, double *xyz, double *dqz)
 	transform_park(-theta, xyz, dqz);
 }
 
-void transform_dqz_inverse(double C, double theta, double *abc, double *dqz)
+void transform_dqz_inverse(transform_dqz_type_e C, double theta, double *abc, double *dqz)
 {
     double xyz[3];
     transform_park_inverse(theta, xyz, dqz);

--- a/sdk/bare/common/sys/transform.c
+++ b/sdk/bare/common/sys/transform.c
@@ -23,9 +23,29 @@ void transform_dqz(double C, double theta, double *abc, double *dqz)
     transform_park(theta, xyz, dqz);
 }
 
+void transform_clarke_inverse(double C, double *abc, double *xyz)
+{
+	if (C == TRANS_DQZ_C_INVARIANT_AMPLITUDE) {
+		abc[0] = 1 * xyz[0]      + 0 * xyz[1]         + xyz[2];
+		abc[1] = -1 / 2 * xyz[0] + SQRT3 / 2 * xyz[1] + xyz[2];
+		abc[2] = -1 / 2 * xyz[0] - SQRT3 / 2 * xyz[1] + xyz[2];
+	}
+	if (C == TRANS_DQZ_C_INVARIANT_POWER) {
+		abc[0] = C * (1 * xyz[0]      + 0 * xyz[1])         + xyz[2];
+		abc[1] = C * (-1 / 2 * xyz[0] + SQRT3 / 2 * xyz[1]) + xyz[2];
+		abc[2] = C * (-1 / 2 * xyz[0] - SQRT3 / 2 * xyz[1]) + xyz[2];
+	}
+}
+
+void transform_park_inverse(double theta, double *xyz, double *dqz)
+{
+	// Rotate backwards
+	transform_park(-theta, xyz, dqz);
+}
+
 void transform_dqz_inverse(double C, double theta, double *abc, double *dqz)
 {
-    abc[0] = C * (cos(theta) * dqz[0] - sin(theta) * dqz[1]) + dqz[2];
-    abc[1] = C * (cos(theta - PI23) * dqz[0] - sin(theta - PI23) * dqz[1]) + dqz[2];
-    abc[2] = C * (cos(theta + PI23) * dqz[0] - sin(theta + PI23) * dqz[1]) + dqz[2];
+    double xyz[3];
+    transform_park_inverse(theta, xyz, dqz);
+    transform_clarke_inverse(C, abc, xyz);
 }

--- a/sdk/bare/common/sys/transform.c
+++ b/sdk/bare/common/sys/transform.c
@@ -5,22 +5,22 @@
 void transform_clarke(transform_dqz_type_e C, double *abc, double *xyz)
 {
     if (C == TRANS_DQZ_C_INVARIANT_AMPLITUDE) {
-        xyz[0] = C_INVARIANT_AMPLITUDE * (1 * abc[0] - 0.5 * abc[1] - 0.5 * abc[2]);
-        xyz[1] = C_INVARIANT_AMPLITUDE * (0 * abc[0] + SQRT3 / 2 * abc[1] - SQRT3 / 2 * abc[2]);
-        xyz[2] = (1 / 3 * abc[0] + 1 / 3 * abc[1] + 1 / 3 * abc[2]);
+        xyz[0] = C_INVARIANT_AMPLITUDE * (1.0 * abc[0] - 0.5 * abc[1] - 0.5 * abc[2]);
+        xyz[1] = C_INVARIANT_AMPLITUDE * (0.0 * abc[0] + SQRT3 / 2.0 * abc[1] - SQRT3 / 2.0 * abc[2]);
+        xyz[2] = (1.0 / 3.0 * abc[0] + 1.0 / 3.0 * abc[1] + 1.0 / 3.0 * abc[2]);
     }
     if (C == TRANS_DQZ_C_INVARIANT_POWER) {
-        xyz[0] = C_INVARIANT_POWER * (1 * abc[0] - 0.5 * abc[1] - 0.5 * abc[2]);
-        xyz[1] = C_INVARIANT_POWER * (0 * abc[0] + SQRT3 / 2 * abc[1] - SQRT3 / 2 * abc[2]);
-        xyz[2] = (1 / SQRT3 * abc[0] + 1 / SQRT3 * abc[1] + 1 / SQRT3 * abc[2]);
+        xyz[0] = C_INVARIANT_POWER * (1.0 * abc[0] - 0.5 * abc[1] - 0.5 * abc[2]);
+        xyz[1] = C_INVARIANT_POWER * (0.0 * abc[0] + SQRT3 / 2.0 * abc[1] - SQRT3 / 2.0 * abc[2]);
+        xyz[2] = (1.0 / SQRT3 * abc[0] + 1.0 / SQRT3 * abc[1] + 1.0 / SQRT3 * abc[2]);
     }
 }
 
 void transform_park(double theta, double *xyz, double *dqz)
 {
-    dqz[0] = +cos(theta) * xyz[0] + sin(theta) * xyz[1] + 0 * xyz[2];
-    dqz[1] = -sin(theta) * xyz[0] + cos(theta) * xyz[1] + 0 * xyz[2];
-    dqz[2] = +0 * xyz[0] + 0 * xyz[1] + 1 * xyz[2];
+    dqz[0] = +cos(theta) * xyz[0] + sin(theta) * xyz[1] + 0.0 * xyz[2];
+    dqz[1] = -sin(theta) * xyz[0] + cos(theta) * xyz[1] + 0.0 * xyz[2];
+    dqz[2] = 0.0 * xyz[0] + 0.0 * xyz[1] + 1.0 * xyz[2];
 }
 
 void transform_dqz(transform_dqz_type_e C, double theta, double *abc, double *dqz)
@@ -33,14 +33,14 @@ void transform_dqz(transform_dqz_type_e C, double theta, double *abc, double *dq
 void transform_clarke_inverse(transform_dqz_type_e C, double *abc, double *xyz)
 {
     if (C == TRANS_DQZ_C_INVARIANT_AMPLITUDE) {
-        abc[0] = 1 * xyz[0] + 0 * xyz[1] + xyz[2];
-        abc[1] = -1 / 2 * xyz[0] + SQRT3 / 2 * xyz[1] + xyz[2];
-        abc[2] = -1 / 2 * xyz[0] - SQRT3 / 2 * xyz[1] + xyz[2];
+        abc[0] = 1.0 * xyz[0] + 0.0 * xyz[1] + 1.0 * xyz[2];
+        abc[1] = -1.0 / 2.0 * xyz[0] + SQRT3 / 2.0 * xyz[1] + 1.0 * xyz[2];
+        abc[2] = -1.0 / 2.0 * xyz[0] - SQRT3 / 2.0 * xyz[1] + 1.0 * xyz[2];
     }
     if (C == TRANS_DQZ_C_INVARIANT_POWER) {
-        abc[0] = C_INVARIANT_POWER * (1 * xyz[0] + 0 * xyz[1] + 1 / SQRT2 * xyz[2]);
-        abc[1] = C_INVARIANT_POWER * (-1 / 2 * xyz[0] + SQRT3 / 2 * xyz[1] + 1 / SQRT2 * xyz[2]);
-        abc[2] = C_INVARIANT_POWER * (-1 / 2 * xyz[0] - SQRT3 / 2 * xyz[1] + 1 / SQRT2 * xyz[2]);
+        abc[0] = C_INVARIANT_POWER * (1.0 * xyz[0] + 0.0 * xyz[1] + 1.0 / SQRT2 * xyz[2]);
+        abc[1] = C_INVARIANT_POWER * (-1.0 / 2.0 * xyz[0] + SQRT3 / 2.0 * xyz[1] + 1.0 / SQRT2 * xyz[2]);
+        abc[2] = C_INVARIANT_POWER * (-1.0 / 2.0 * xyz[0] - SQRT3 / 2.0 * xyz[1] + 1.0 / SQRT2 * xyz[2]);
     }
 }
 

--- a/sdk/bare/common/sys/transform.c
+++ b/sdk/bare/common/sys/transform.c
@@ -6,7 +6,12 @@ void transform_clarke(double C, double *abc, double *xyz)
 {
     xyz[0] = C * (1 * abc[0] - 0.5 * abc[1] - 0.5 * abc[2]);
     xyz[1] = C * (0 * abc[0] + SQRT3 / 2 * abc[1] - SQRT3 / 2 * abc[2]);
-    xyz[2] = (1 / 3 * abc[0] + 1 / 3 * abc[1] + 1 / 3 * abc[2]);
+    if (C == TRANS_DQZ_C_INVARIANT_AMPLITUDE) {
+    	xyz[2] = (1 / 3 * abc[0] + 1 / 3 * abc[1] + 1 / 3 * abc[2]);
+	}
+    if (C == TRANS_DQZ_C_INVARIANT_POWER) {
+		xyz[2] = (1 / SQRT3 * abc[0] + 1 / SQRT3 * abc[1] + 1 / SQRT3 * abc[2]);
+	}
 }
 
 void transform_park(double theta, double *xyz, double *dqz)
@@ -26,14 +31,14 @@ void transform_dqz(double C, double theta, double *abc, double *dqz)
 void transform_clarke_inverse(double C, double *abc, double *xyz)
 {
 	if (C == TRANS_DQZ_C_INVARIANT_AMPLITUDE) {
-		abc[0] = 1 * xyz[0]      + 0 * xyz[1]         + xyz[2];
+		abc[0] = 1 * xyz[0] + 0 * xyz[1] + xyz[2];
 		abc[1] = -1 / 2 * xyz[0] + SQRT3 / 2 * xyz[1] + xyz[2];
 		abc[2] = -1 / 2 * xyz[0] - SQRT3 / 2 * xyz[1] + xyz[2];
 	}
 	if (C == TRANS_DQZ_C_INVARIANT_POWER) {
-		abc[0] = C * (1 * xyz[0]      + 0 * xyz[1])         + xyz[2];
-		abc[1] = C * (-1 / 2 * xyz[0] + SQRT3 / 2 * xyz[1]) + xyz[2];
-		abc[2] = C * (-1 / 2 * xyz[0] - SQRT3 / 2 * xyz[1]) + xyz[2];
+		abc[0] = C * (1 * xyz[0] + 0 * xyz[1] + 1 / SQRT2 * xyz[2]);
+		abc[1] = C * (-1 / 2 * xyz[0] + SQRT3 / 2 * xyz[1] + 1 / SQRT2 * xyz[2]);
+		abc[2] = C * (-1 / 2 * xyz[0] - SQRT3 / 2 * xyz[1] + 1 / SQRT2 * xyz[2]);
 	}
 }
 

--- a/sdk/bare/common/sys/transform.c
+++ b/sdk/bare/common/sys/transform.c
@@ -56,4 +56,3 @@ void transform_dqz_inverse(transform_dqz_type_e C, double theta, double *abc, do
     transform_park_inverse(theta, xyz, dqz);
     transform_clarke_inverse(C, abc, xyz);
 }
-

--- a/sdk/bare/common/sys/transform.h
+++ b/sdk/bare/common/sys/transform.h
@@ -10,4 +10,7 @@ void transform_dqz_inverse(double C, double theta, double *abc, double *dqz);
 void transform_clarke(double C, double *abc, double *xyz);
 void transform_park(double theta, double *xyz, double *dqz);
 
+void transform_clarke_inverse(double C, double *abc, double *xyz);
+void transform_park_inverse(double theta, double *xyz, double *dqz);
+
 #endif // TRANSFORM_H

--- a/sdk/bare/common/sys/transform.h
+++ b/sdk/bare/common/sys/transform.h
@@ -1,16 +1,21 @@
 #ifndef TRANSFORM_H
 #define TRANSFORM_H
 
-#define TRANS_DQZ_C_INVARIANT_POWER     (0.816496580927726032732) // sqrt(2/3)
-#define TRANS_DQZ_C_INVARIANT_AMPLITUDE (0.666666666666666666667) // 2/3
+#define C_INVARIANT_POWER     (0.816496580927726032732) // sqrt(2/3)
+#define C_INVARIANT_AMPLITUDE (0.666666666666666666667) // 2/3
 
-void transform_dqz(double C, double theta, double *abc, double *dqz);
-void transform_dqz_inverse(double C, double theta, double *abc, double *dqz);
+typedef enum {
+  TRANS_DQZ_C_INVARIANT_AMPLITUDE = 0,
+  TRANS_DQZ_C_INVARIANT_POWER
+} transform_dqz_type_e;
 
-void transform_clarke(double C, double *abc, double *xyz);
+void transform_dqz(transform_dqz_type_e C, double theta, double *abc, double *dqz);
+void transform_dqz_inverse(transform_dqz_type_e C, double theta, double *abc, double *dqz);
+
+void transform_clarke(transform_dqz_type_e C, double *abc, double *xyz);
 void transform_park(double theta, double *xyz, double *dqz);
 
-void transform_clarke_inverse(double C, double *abc, double *xyz);
+void transform_clarke_inverse(transform_dqz_type_e C, double *abc, double *xyz);
 void transform_park_inverse(double theta, double *xyz, double *dqz);
 
 #endif // TRANSFORM_H

--- a/sdk/bare/common/sys/transform.h
+++ b/sdk/bare/common/sys/transform.h
@@ -4,10 +4,7 @@
 #define C_INVARIANT_POWER     (0.816496580927726032732) // sqrt(2/3)
 #define C_INVARIANT_AMPLITUDE (0.666666666666666666667) // 2/3
 
-typedef enum {
-  TRANS_DQZ_C_INVARIANT_AMPLITUDE = 0,
-  TRANS_DQZ_C_INVARIANT_POWER
-} transform_dqz_type_e;
+typedef enum { TRANS_DQZ_C_INVARIANT_AMPLITUDE = 0, TRANS_DQZ_C_INVARIANT_POWER } transform_dqz_type_e;
 
 void transform_dqz(transform_dqz_type_e C, double theta, double *abc, double *dqz);
 void transform_dqz_inverse(transform_dqz_type_e C, double theta, double *abc, double *dqz);


### PR DESCRIPTION
In this PR, the transformation matrix for power and amplitude invariant transformation is corrected.
 - The zero-sequence transformation for power-invariant is corrected.
- The inverse transformation matrix was wrong as it was incorrectly scaling the phase currents, this is also rectified in this PR.
- To avoid confusion, Clarke's and Parke's transformations are used to transform and to inverse transform.

References:
[1] https://www.mathworks.com/help/physmod/sps/ref/clarketransform.html
[2] https://www.mathworks.com/help/physmod/sps/ref/inverseclarketransform.html
[3] https://www.mathworks.com/help/physmod/sps/ref/parktransform.html
[4] https://www.mathworks.com/help/physmod/sps/ref/inverseparktransform.html