### PR TITLE
Add PWM reset signal for AMDC REVD

### DIFF
--- a/sdk/bare/common/drv/pwm.c
+++ b/sdk/bare/common/drv/pwm.c
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#define PWM_BASE_ADDR (0x43C20000)
+#define PWM_BASE_ADDR     (0x43C20000)
 #define PWM_MUX_BASE_ADDR (0x43C40000)
 
 static int pwm_set_carrier_divisor(uint8_t divisor);

--- a/sdk/bare/common/drv/pwm.c
+++ b/sdk/bare/common/drv/pwm.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 
 #define PWM_BASE_ADDR (0x43C20000)
+#define PWM_MUX_BASE_ADDR (0x43C40000)
 
 static int pwm_set_carrier_divisor(uint8_t divisor);
 static int pwm_set_carrier_max(uint16_t max);
@@ -43,6 +44,13 @@ void pwm_init(void)
     // but if user enables PWM without updating registers,
     // 50% will appear at outputs.
     pwm_set_all_duty_midscale();
+
+    // Initialize the PWM mux block in the FPGA to basic pass-through
+    uint32_t mux_config_data[48];
+    for (int i = 0; i < 48; i++) {
+        mux_config_data[i] = i;
+    }
+    pwm_mux_set_all_pins(mux_config_data);
 }
 
 void pwm_set_all_duty_midscale(void)
@@ -54,7 +62,6 @@ void pwm_set_all_duty_midscale(void)
 
 void pwm_toggle_reset(void)
 {
-
     // Toggles RST on all inverter outputs for 1 ms
     pwm_set_all_rst(0xFF);
     for (int i = 0; i < 83250; i++) {
@@ -65,7 +72,6 @@ void pwm_toggle_reset(void)
         asm("nop");
     }
     pwm_set_all_rst(0xFF);
-
 }
 
 void pwm_set_all_rst(uint8_t rst)
@@ -238,6 +244,37 @@ static int pwm_set_carrier_max(uint16_t max)
 
     // Since we updated carrier max value, reset PWMs to new 50%
     pwm_set_all_duty_midscale();
+
+    return SUCCESS;
+}
+
+// NOTE: we assume config is an array of length >= 48
+int pwm_mux_set_all_pins(uint32_t *config)
+{
+    // Only allow PWM configuration changes when switching is off
+    if (pwm_is_enabled()) {
+        return FAILURE;
+    }
+
+    for (int i = 0; i < (PWM_NUM_CHANNELS * 2); i++) {
+        Xil_Out32(PWM_MUX_BASE_ADDR + (i * sizeof(uint32_t)), config[i]);
+    }
+
+    return SUCCESS;
+}
+
+int pwm_mux_set_one_pin(uint32_t pwm_pin_idx, uint32_t config)
+{
+    // Only allow PWM configuration changes when switching is off
+    if (pwm_is_enabled()) {
+        return FAILURE;
+    }
+
+    if (pwm_pin_idx < 0 || pwm_pin_idx >= 48) {
+        return FAILURE;
+    }
+
+    Xil_Out32(PWM_MUX_BASE_ADDR + (pwm_pin_idx * sizeof(uint32_t)), config);
 
     return SUCCESS;
 }


### PR DESCRIPTION
Power stack inverter REVB requires a reset signal for the inverter to operate. This PR will add the functionality to provide reset signals during PWM initialization. This operation of the power stack board is verified.