### PR TITLE
CAN REV-A Firmware

### DIFF
--- a/hw/amdc_revd.bd
+++ b/hw/amdc_revd.bd
@@ -70,7 +70,8 @@
       "amdc_gpio_mux_0": "",
       "xlslice_0": "",
       "xlconcat_2": "",
-      "xlconstant_7": ""
+      "xlconstant_7": "",
+      "xlslice_1": ""
     },
     "interface_ports": {
       "DDR": {
@@ -2110,16 +2111,16 @@
               }
             },
             "interface_nets": {
-              "auto_pc_to_s00_couplers": {
-                "interface_ports": [
-                  "M_AXI",
-                  "auto_pc/M_AXI"
-                ]
-              },
               "s00_couplers_to_auto_pc": {
                 "interface_ports": [
                   "S_AXI",
                   "auto_pc/S_AXI"
+                ]
+              },
+              "auto_pc_to_s00_couplers": {
+                "interface_ports": [
+                  "M_AXI",
+                  "auto_pc/M_AXI"
                 ]
               }
             },
@@ -2198,16 +2199,16 @@
               }
             },
             "interface_nets": {
-              "auto_pc_to_m00_couplers": {
-                "interface_ports": [
-                  "M_AXI",
-                  "auto_pc/M_AXI"
-                ]
-              },
               "m00_couplers_to_auto_pc": {
                 "interface_ports": [
                   "S_AXI",
                   "auto_pc/S_AXI"
+                ]
+              },
+              "auto_pc_to_m00_couplers": {
+                "interface_ports": [
+                  "M_AXI",
+                  "auto_pc/M_AXI"
                 ]
               }
             },
@@ -2462,16 +2463,16 @@
               }
             },
             "interface_nets": {
-              "m03_couplers_to_auto_pc": {
-                "interface_ports": [
-                  "S_AXI",
-                  "auto_pc/S_AXI"
-                ]
-              },
               "auto_pc_to_m03_couplers": {
                 "interface_ports": [
                   "M_AXI",
                   "auto_pc/M_AXI"
+                ]
+              },
+              "m03_couplers_to_auto_pc": {
+                "interface_ports": [
+                  "S_AXI",
+                  "auto_pc/S_AXI"
                 ]
               }
             },
@@ -2550,16 +2551,16 @@
               }
             },
             "interface_nets": {
-              "m04_couplers_to_auto_pc": {
-                "interface_ports": [
-                  "S_AXI",
-                  "auto_pc/S_AXI"
-                ]
-              },
               "auto_pc_to_m04_couplers": {
                 "interface_ports": [
                   "M_AXI",
                   "auto_pc/M_AXI"
+                ]
+              },
+              "m04_couplers_to_auto_pc": {
+                "interface_ports": [
+                  "S_AXI",
+                  "auto_pc/S_AXI"
                 ]
               }
             },
@@ -3182,24 +3183,6 @@
           }
         },
         "interface_nets": {
-          "xbar_to_m00_couplers": {
-            "interface_ports": [
-              "xbar/M00_AXI",
-              "m00_couplers/S_AXI"
-            ]
-          },
-          "m01_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M01_AXI",
-              "m01_couplers/M_AXI"
-            ]
-          },
-          "xbar_to_m12_couplers": {
-            "interface_ports": [
-              "xbar/M12_AXI",
-              "m12_couplers/S_AXI"
-            ]
-          },
           "s00_couplers_to_xbar": {
             "interface_ports": [
               "s00_couplers/M_AXI",
@@ -3212,88 +3195,16 @@
               "m00_couplers/M_AXI"
             ]
           },
-          "ps7_0_axi_periph_to_s00_couplers": {
+          "m01_couplers_to_ps7_0_axi_periph": {
             "interface_ports": [
-              "S00_AXI",
-              "s00_couplers/S_AXI"
+              "M01_AXI",
+              "m01_couplers/M_AXI"
             ]
           },
-          "m06_couplers_to_ps7_0_axi_periph": {
+          "xbar_to_m00_couplers": {
             "interface_ports": [
-              "M06_AXI",
-              "m06_couplers/M_AXI"
-            ]
-          },
-          "xbar_to_m06_couplers": {
-            "interface_ports": [
-              "xbar/M06_AXI",
-              "m06_couplers/S_AXI"
-            ]
-          },
-          "m07_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M07_AXI",
-              "m07_couplers/M_AXI"
-            ]
-          },
-          "xbar_to_m07_couplers": {
-            "interface_ports": [
-              "xbar/M07_AXI",
-              "m07_couplers/S_AXI"
-            ]
-          },
-          "m08_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M08_AXI",
-              "m08_couplers/M_AXI"
-            ]
-          },
-          "xbar_to_m08_couplers": {
-            "interface_ports": [
-              "xbar/M08_AXI",
-              "m08_couplers/S_AXI"
-            ]
-          },
-          "m09_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M09_AXI",
-              "m09_couplers/M_AXI"
-            ]
-          },
-          "xbar_to_m09_couplers": {
-            "interface_ports": [
-              "xbar/M09_AXI",
-              "m09_couplers/S_AXI"
-            ]
-          },
-          "m10_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M10_AXI",
-              "m10_couplers/M_AXI"
-            ]
-          },
-          "xbar_to_m10_couplers": {
-            "interface_ports": [
-              "xbar/M10_AXI",
-              "m10_couplers/S_AXI"
-            ]
-          },
-          "m11_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M11_AXI",
-              "m11_couplers/M_AXI"
-            ]
-          },
-          "xbar_to_m11_couplers": {
-            "interface_ports": [
-              "xbar/M11_AXI",
-              "m11_couplers/S_AXI"
-            ]
-          },
-          "m12_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M12_AXI",
-              "m12_couplers/M_AXI"
+              "xbar/M00_AXI",
+              "m00_couplers/S_AXI"
             ]
           },
           "xbar_to_m01_couplers": {
@@ -3308,16 +3219,16 @@
               "m02_couplers/M_AXI"
             ]
           },
-          "m03_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M03_AXI",
-              "m03_couplers/M_AXI"
-            ]
-          },
           "xbar_to_m02_couplers": {
             "interface_ports": [
               "xbar/M02_AXI",
               "m02_couplers/S_AXI"
+            ]
+          },
+          "m03_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M03_AXI",
+              "m03_couplers/M_AXI"
             ]
           },
           "xbar_to_m03_couplers": {
@@ -3344,10 +3255,100 @@
               "m05_couplers/M_AXI"
             ]
           },
+          "m06_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M06_AXI",
+              "m06_couplers/M_AXI"
+            ]
+          },
           "xbar_to_m05_couplers": {
             "interface_ports": [
               "xbar/M05_AXI",
               "m05_couplers/S_AXI"
+            ]
+          },
+          "m07_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M07_AXI",
+              "m07_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m06_couplers": {
+            "interface_ports": [
+              "xbar/M06_AXI",
+              "m06_couplers/S_AXI"
+            ]
+          },
+          "xbar_to_m07_couplers": {
+            "interface_ports": [
+              "xbar/M07_AXI",
+              "m07_couplers/S_AXI"
+            ]
+          },
+          "m08_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M08_AXI",
+              "m08_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m08_couplers": {
+            "interface_ports": [
+              "xbar/M08_AXI",
+              "m08_couplers/S_AXI"
+            ]
+          },
+          "m09_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M09_AXI",
+              "m09_couplers/M_AXI"
+            ]
+          },
+          "m10_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M10_AXI",
+              "m10_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m09_couplers": {
+            "interface_ports": [
+              "xbar/M09_AXI",
+              "m09_couplers/S_AXI"
+            ]
+          },
+          "xbar_to_m10_couplers": {
+            "interface_ports": [
+              "xbar/M10_AXI",
+              "m10_couplers/S_AXI"
+            ]
+          },
+          "m11_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M11_AXI",
+              "m11_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m11_couplers": {
+            "interface_ports": [
+              "xbar/M11_AXI",
+              "m11_couplers/S_AXI"
+            ]
+          },
+          "m12_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M12_AXI",
+              "m12_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m12_couplers": {
+            "interface_ports": [
+              "xbar/M12_AXI",
+              "m12_couplers/S_AXI"
+            ]
+          },
+          "ps7_0_axi_periph_to_s00_couplers": {
+            "interface_ports": [
+              "S00_AXI",
+              "s00_couplers/S_AXI"
             ]
           }
         },
@@ -3714,6 +3715,24 @@
             "value": "0"
           }
         }
+      },
+      "xlslice_1": {
+        "vlnv": "xilinx.com:ip:xlslice:1.0",
+        "xci_name": "amdc_revd_xlslice_1_0",
+        "parameters": {
+          "DIN_FROM": {
+            "value": "1"
+          },
+          "DIN_TO": {
+            "value": "1"
+          },
+          "DIN_WIDTH": {
+            "value": "2"
+          },
+          "DOUT_WIDTH": {
+            "value": "1"
+          }
+        }
       }
     },
     "interface_nets": {
@@ -3723,10 +3742,10 @@
           "processing_system7_0/DDR"
         ]
       },
-      "ps7_0_axi_periph_M07_AXI": {
+      "ps7_0_axi_periph_M04_AXI": {
         "interface_ports": [
-          "ps7_0_axi_periph/M07_AXI",
-          "amdc_inv_status_mux_0/S00_AXI"
+          "ps7_0_axi_periph/M04_AXI",
+          "control_timer_1/S_AXI"
         ]
       },
       "ps7_0_axi_periph_M03_AXI": {
@@ -3735,22 +3754,16 @@
           "control_timer_0/S_AXI"
         ]
       },
-      "ps7_0_axi_periph_M08_AXI": {
-        "interface_ports": [
-          "ps7_0_axi_periph/M08_AXI",
-          "amdc_dac_0/S00_AXI"
-        ]
-      },
       "ps7_0_axi_periph_M06_AXI": {
         "interface_ports": [
           "ps7_0_axi_periph/M06_AXI",
           "amdc_pwm_mux_0/S00_AXI"
         ]
       },
-      "ps7_0_axi_periph_M01_AXI": {
+      "ps7_0_axi_periph_M07_AXI": {
         "interface_ports": [
-          "ps7_0_axi_periph/M01_AXI",
-          "amdc_encoder_0/S00_AXI"
+          "ps7_0_axi_periph/M07_AXI",
+          "amdc_inv_status_mux_0/S00_AXI"
         ]
       },
       "processing_system7_0_FIXED_IO": {
@@ -3759,16 +3772,28 @@
           "processing_system7_0/FIXED_IO"
         ]
       },
+      "ps7_0_axi_periph_M09_AXI": {
+        "interface_ports": [
+          "ps7_0_axi_periph/M09_AXI",
+          "amdc_gpio_mux_0/S00_AXI"
+        ]
+      },
       "processing_system7_0_M_AXI_GP0": {
         "interface_ports": [
           "processing_system7_0/M_AXI_GP0",
           "ps7_0_axi_periph/S00_AXI"
         ]
       },
-      "ps7_0_axi_periph_M04_AXI": {
+      "ps7_0_axi_periph_M08_AXI": {
         "interface_ports": [
-          "ps7_0_axi_periph/M04_AXI",
-          "control_timer_1/S_AXI"
+          "ps7_0_axi_periph/M08_AXI",
+          "amdc_dac_0/S00_AXI"
+        ]
+      },
+      "ps7_0_axi_periph_M05_AXI": {
+        "interface_ports": [
+          "ps7_0_axi_periph/M05_AXI",
+          "amdc_leds_0/S00_AXI"
         ]
       },
       "ps7_0_axi_periph_M02_AXI": {
@@ -3783,16 +3808,10 @@
           "amdc_adc_0/S00_AXI"
         ]
       },
-      "ps7_0_axi_periph_M09_AXI": {
+      "ps7_0_axi_periph_M01_AXI": {
         "interface_ports": [
-          "ps7_0_axi_periph/M09_AXI",
-          "amdc_gpio_mux_0/S00_AXI"
-        ]
-      },
-      "ps7_0_axi_periph_M05_AXI": {
-        "interface_ports": [
-          "ps7_0_axi_periph/M05_AXI",
-          "amdc_leds_0/S00_AXI"
+          "ps7_0_axi_periph/M01_AXI",
+          "amdc_encoder_0/S00_AXI"
         ]
       }
     },
@@ -4251,16 +4270,28 @@
           "xlslice_0/Din"
         ]
       },
-      "xlconcat_2_dout": {
-        "ports": [
-          "xlconcat_2/dout",
-          "amdc_gpio_mux_0/device_out_1"
-        ]
-      },
       "xlconstant_7_dout": {
         "ports": [
           "xlconstant_7/dout",
           "xlconcat_2/In1"
+        ]
+      },
+      "xlslice_0_Dout": {
+        "ports": [
+          "xlslice_0/Dout",
+          "processing_system7_0/CAN0_PHY_RX"
+        ]
+      },
+      "processing_system7_0_CAN0_PHY_TX": {
+        "ports": [
+          "processing_system7_0/CAN0_PHY_TX",
+          "xlslice_1/Din"
+        ]
+      },
+      "xlslice_1_Dout": {
+        "ports": [
+          "xlslice_1/Dout",
+          "amdc_gpio_mux_0/device_out_1"
         ]
       }
     },

--- a/hw/amdc_revd.bd
+++ b/hw/amdc_revd.bd
@@ -71,6 +71,8 @@
       "xlslice_0": "",
       "xlconcat_2": "",
       "xlconstant_7": "",
+      "xlconcat_3": "",
+      "xlconstant_8": "",
       "xlslice_1": ""
     },
     "interface_ports": {
@@ -820,7 +822,7 @@
             "value": "667"
           },
           "PCW_CAN0_CAN0_IO": {
-            "value": "EMIO"
+            "value": "MIO 30 .. 31"
           },
           "PCW_CAN0_GRP_CLK_ENABLE": {
             "value": "0"
@@ -829,7 +831,7 @@
             "value": "1"
           },
           "PCW_CAN1_CAN1_IO": {
-            "value": "EMIO"
+            "value": "MIO 32 .. 33"
           },
           "PCW_CAN1_GRP_CLK_ENABLE": {
             "value": "0"
@@ -925,10 +927,10 @@
             "value": "1"
           },
           "PCW_EN_EMIO_CAN0": {
-            "value": "1"
+            "value": "0"
           },
           "PCW_EN_EMIO_CAN1": {
-            "value": "1"
+            "value": "0"
           },
           "PCW_EN_EMIO_CD_SDIO1": {
             "value": "1"
@@ -1492,10 +1494,10 @@
             "value": "54"
           },
           "PCW_MIO_TREE_PERIPHERALS": {
-            "value": "GPIO#Quad SPI Flash#Quad SPI Flash#Quad SPI Flash#Quad SPI Flash#Quad SPI Flash#Quad SPI Flash#GPIO#GPIO#GPIO#SD 1#SD 1#SD 1#SD 1#SD 1#SD 1#Enet 0#Enet 0#Enet 0#Enet 0#Enet 0#Enet 0#Enet 0#Enet 0#Enet 0#Enet 0#Enet 0#Enet 0#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#UART 0#UART 0#GPIO#GPIO"
+            "value": "GPIO#Quad SPI Flash#Quad SPI Flash#Quad SPI Flash#Quad SPI Flash#Quad SPI Flash#Quad SPI Flash#GPIO#GPIO#GPIO#SD 1#SD 1#SD 1#SD 1#SD 1#SD 1#Enet 0#Enet 0#Enet 0#Enet 0#Enet 0#Enet 0#Enet 0#Enet 0#Enet 0#Enet 0#Enet 0#Enet 0#GPIO#GPIO#CAN 0#CAN 0#CAN 1#CAN 1#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#GPIO#UART 0#UART 0#GPIO#GPIO"
           },
           "PCW_MIO_TREE_SIGNALS": {
-            "value": "gpio[0]#qspi0_ss_b#qspi0_io[0]#qspi0_io[1]#qspi0_io[2]#qspi0_io[3]/HOLD_B#qspi0_sclk#gpio[7]#gpio[8]#gpio[9]#data[0]#cmd#clk#data[1]#data[2]#data[3]#tx_clk#txd[0]#txd[1]#txd[2]#txd[3]#tx_ctl#rx_clk#rxd[0]#rxd[1]#rxd[2]#rxd[3]#rx_ctl#gpio[28]#gpio[29]#gpio[30]#gpio[31]#gpio[32]#gpio[33]#gpio[34]#gpio[35]#gpio[36]#gpio[37]#gpio[38]#gpio[39]#gpio[40]#gpio[41]#gpio[42]#gpio[43]#gpio[44]#gpio[45]#gpio[46]#gpio[47]#gpio[48]#gpio[49]#rx#tx#gpio[52]#gpio[53]"
+            "value": "gpio[0]#qspi0_ss_b#qspi0_io[0]#qspi0_io[1]#qspi0_io[2]#qspi0_io[3]/HOLD_B#qspi0_sclk#gpio[7]#gpio[8]#gpio[9]#data[0]#cmd#clk#data[1]#data[2]#data[3]#tx_clk#txd[0]#txd[1]#txd[2]#txd[3]#tx_ctl#rx_clk#rxd[0]#rxd[1]#rxd[2]#rxd[3]#rx_ctl#gpio[28]#gpio[29]#rx#tx#tx#rx#gpio[34]#gpio[35]#gpio[36]#gpio[37]#gpio[38]#gpio[39]#gpio[40]#gpio[41]#gpio[42]#gpio[43]#gpio[44]#gpio[45]#gpio[46]#gpio[47]#gpio[48]#gpio[49]#rx#tx#gpio[52]#gpio[53]"
           },
           "PCW_P2F_UART0_INTR": {
             "value": "1"
@@ -2111,16 +2113,16 @@
               }
             },
             "interface_nets": {
-              "s00_couplers_to_auto_pc": {
-                "interface_ports": [
-                  "S_AXI",
-                  "auto_pc/S_AXI"
-                ]
-              },
               "auto_pc_to_s00_couplers": {
                 "interface_ports": [
                   "M_AXI",
                   "auto_pc/M_AXI"
+                ]
+              },
+              "s00_couplers_to_auto_pc": {
+                "interface_ports": [
+                  "S_AXI",
+                  "auto_pc/S_AXI"
                 ]
               }
             },
@@ -2199,16 +2201,16 @@
               }
             },
             "interface_nets": {
-              "m00_couplers_to_auto_pc": {
-                "interface_ports": [
-                  "S_AXI",
-                  "auto_pc/S_AXI"
-                ]
-              },
               "auto_pc_to_m00_couplers": {
                 "interface_ports": [
                   "M_AXI",
                   "auto_pc/M_AXI"
+                ]
+              },
+              "m00_couplers_to_auto_pc": {
+                "interface_ports": [
+                  "S_AXI",
+                  "auto_pc/S_AXI"
                 ]
               }
             },
@@ -2287,16 +2289,16 @@
               }
             },
             "interface_nets": {
-              "auto_pc_to_m01_couplers": {
-                "interface_ports": [
-                  "M_AXI",
-                  "auto_pc/M_AXI"
-                ]
-              },
               "m01_couplers_to_auto_pc": {
                 "interface_ports": [
                   "S_AXI",
                   "auto_pc/S_AXI"
+                ]
+              },
+              "auto_pc_to_m01_couplers": {
+                "interface_ports": [
+                  "M_AXI",
+                  "auto_pc/M_AXI"
                 ]
               }
             },
@@ -2463,16 +2465,16 @@
               }
             },
             "interface_nets": {
-              "auto_pc_to_m03_couplers": {
-                "interface_ports": [
-                  "M_AXI",
-                  "auto_pc/M_AXI"
-                ]
-              },
               "m03_couplers_to_auto_pc": {
                 "interface_ports": [
                   "S_AXI",
                   "auto_pc/S_AXI"
+                ]
+              },
+              "auto_pc_to_m03_couplers": {
+                "interface_ports": [
+                  "M_AXI",
+                  "auto_pc/M_AXI"
                 ]
               }
             },
@@ -2551,16 +2553,16 @@
               }
             },
             "interface_nets": {
-              "auto_pc_to_m04_couplers": {
-                "interface_ports": [
-                  "M_AXI",
-                  "auto_pc/M_AXI"
-                ]
-              },
               "m04_couplers_to_auto_pc": {
                 "interface_ports": [
                   "S_AXI",
                   "auto_pc/S_AXI"
+                ]
+              },
+              "auto_pc_to_m04_couplers": {
+                "interface_ports": [
+                  "M_AXI",
+                  "auto_pc/M_AXI"
                 ]
               }
             },
@@ -2639,16 +2641,16 @@
               }
             },
             "interface_nets": {
-              "auto_pc_to_m05_couplers": {
-                "interface_ports": [
-                  "M_AXI",
-                  "auto_pc/M_AXI"
-                ]
-              },
               "m05_couplers_to_auto_pc": {
                 "interface_ports": [
                   "S_AXI",
                   "auto_pc/S_AXI"
+                ]
+              },
+              "auto_pc_to_m05_couplers": {
+                "interface_ports": [
+                  "M_AXI",
+                  "auto_pc/M_AXI"
                 ]
               }
             },
@@ -2727,16 +2729,16 @@
               }
             },
             "interface_nets": {
-              "auto_pc_to_m06_couplers": {
-                "interface_ports": [
-                  "M_AXI",
-                  "auto_pc/M_AXI"
-                ]
-              },
               "m06_couplers_to_auto_pc": {
                 "interface_ports": [
                   "S_AXI",
                   "auto_pc/S_AXI"
+                ]
+              },
+              "auto_pc_to_m06_couplers": {
+                "interface_ports": [
+                  "M_AXI",
+                  "auto_pc/M_AXI"
                 ]
               }
             },
@@ -2903,16 +2905,16 @@
               }
             },
             "interface_nets": {
-              "m08_couplers_to_auto_pc": {
-                "interface_ports": [
-                  "S_AXI",
-                  "auto_pc/S_AXI"
-                ]
-              },
               "auto_pc_to_m08_couplers": {
                 "interface_ports": [
                   "M_AXI",
                   "auto_pc/M_AXI"
+                ]
+              },
+              "m08_couplers_to_auto_pc": {
+                "interface_ports": [
+                  "S_AXI",
+                  "auto_pc/S_AXI"
                 ]
               }
             },
@@ -2991,16 +2993,16 @@
               }
             },
             "interface_nets": {
-              "auto_pc_to_m09_couplers": {
-                "interface_ports": [
-                  "M_AXI",
-                  "auto_pc/M_AXI"
-                ]
-              },
               "m09_couplers_to_auto_pc": {
                 "interface_ports": [
                   "S_AXI",
                   "auto_pc/S_AXI"
+                ]
+              },
+              "auto_pc_to_m09_couplers": {
+                "interface_ports": [
+                  "M_AXI",
+                  "auto_pc/M_AXI"
                 ]
               }
             },
@@ -3183,16 +3185,88 @@
           }
         },
         "interface_nets": {
-          "s00_couplers_to_xbar": {
+          "xbar_to_m11_couplers": {
             "interface_ports": [
-              "s00_couplers/M_AXI",
-              "xbar/S00_AXI"
+              "xbar/M11_AXI",
+              "m11_couplers/S_AXI"
             ]
           },
-          "m00_couplers_to_ps7_0_axi_periph": {
+          "m12_couplers_to_ps7_0_axi_periph": {
             "interface_ports": [
-              "M00_AXI",
-              "m00_couplers/M_AXI"
+              "M12_AXI",
+              "m12_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m12_couplers": {
+            "interface_ports": [
+              "xbar/M12_AXI",
+              "m12_couplers/S_AXI"
+            ]
+          },
+          "m06_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M06_AXI",
+              "m06_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m06_couplers": {
+            "interface_ports": [
+              "xbar/M06_AXI",
+              "m06_couplers/S_AXI"
+            ]
+          },
+          "m07_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M07_AXI",
+              "m07_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m07_couplers": {
+            "interface_ports": [
+              "xbar/M07_AXI",
+              "m07_couplers/S_AXI"
+            ]
+          },
+          "m08_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M08_AXI",
+              "m08_couplers/M_AXI"
+            ]
+          },
+          "m09_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M09_AXI",
+              "m09_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m08_couplers": {
+            "interface_ports": [
+              "xbar/M08_AXI",
+              "m08_couplers/S_AXI"
+            ]
+          },
+          "xbar_to_m09_couplers": {
+            "interface_ports": [
+              "xbar/M09_AXI",
+              "m09_couplers/S_AXI"
+            ]
+          },
+          "m10_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M10_AXI",
+              "m10_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m10_couplers": {
+            "interface_ports": [
+              "xbar/M10_AXI",
+              "m10_couplers/S_AXI"
+            ]
+          },
+          "m11_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M11_AXI",
+              "m11_couplers/M_AXI"
             ]
           },
           "m01_couplers_to_ps7_0_axi_periph": {
@@ -3225,6 +3299,24 @@
               "m02_couplers/S_AXI"
             ]
           },
+          "ps7_0_axi_periph_to_s00_couplers": {
+            "interface_ports": [
+              "S00_AXI",
+              "s00_couplers/S_AXI"
+            ]
+          },
+          "s00_couplers_to_xbar": {
+            "interface_ports": [
+              "s00_couplers/M_AXI",
+              "xbar/S00_AXI"
+            ]
+          },
+          "m00_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M00_AXI",
+              "m00_couplers/M_AXI"
+            ]
+          },
           "m03_couplers_to_ps7_0_axi_periph": {
             "interface_ports": [
               "M03_AXI",
@@ -3255,100 +3347,10 @@
               "m05_couplers/M_AXI"
             ]
           },
-          "m06_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M06_AXI",
-              "m06_couplers/M_AXI"
-            ]
-          },
           "xbar_to_m05_couplers": {
             "interface_ports": [
               "xbar/M05_AXI",
               "m05_couplers/S_AXI"
-            ]
-          },
-          "m07_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M07_AXI",
-              "m07_couplers/M_AXI"
-            ]
-          },
-          "xbar_to_m06_couplers": {
-            "interface_ports": [
-              "xbar/M06_AXI",
-              "m06_couplers/S_AXI"
-            ]
-          },
-          "xbar_to_m07_couplers": {
-            "interface_ports": [
-              "xbar/M07_AXI",
-              "m07_couplers/S_AXI"
-            ]
-          },
-          "m08_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M08_AXI",
-              "m08_couplers/M_AXI"
-            ]
-          },
-          "xbar_to_m08_couplers": {
-            "interface_ports": [
-              "xbar/M08_AXI",
-              "m08_couplers/S_AXI"
-            ]
-          },
-          "m09_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M09_AXI",
-              "m09_couplers/M_AXI"
-            ]
-          },
-          "m10_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M10_AXI",
-              "m10_couplers/M_AXI"
-            ]
-          },
-          "xbar_to_m09_couplers": {
-            "interface_ports": [
-              "xbar/M09_AXI",
-              "m09_couplers/S_AXI"
-            ]
-          },
-          "xbar_to_m10_couplers": {
-            "interface_ports": [
-              "xbar/M10_AXI",
-              "m10_couplers/S_AXI"
-            ]
-          },
-          "m11_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M11_AXI",
-              "m11_couplers/M_AXI"
-            ]
-          },
-          "xbar_to_m11_couplers": {
-            "interface_ports": [
-              "xbar/M11_AXI",
-              "m11_couplers/S_AXI"
-            ]
-          },
-          "m12_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M12_AXI",
-              "m12_couplers/M_AXI"
-            ]
-          },
-          "xbar_to_m12_couplers": {
-            "interface_ports": [
-              "xbar/M12_AXI",
-              "m12_couplers/S_AXI"
-            ]
-          },
-          "ps7_0_axi_periph_to_s00_couplers": {
-            "interface_ports": [
-              "S00_AXI",
-              "s00_couplers/S_AXI"
             ]
           }
         },
@@ -3716,9 +3718,25 @@
           }
         }
       },
+      "xlconcat_3": {
+        "vlnv": "xilinx.com:ip:xlconcat:2.1",
+        "xci_name": "amdc_revd_xlconcat_3_1"
+      },
+      "xlconstant_8": {
+        "vlnv": "xilinx.com:ip:xlconstant:1.1",
+        "xci_name": "amdc_revd_xlconstant_6_2",
+        "parameters": {
+          "CONST_VAL": {
+            "value": "0"
+          },
+          "CONST_WIDTH": {
+            "value": "2"
+          }
+        }
+      },
       "xlslice_1": {
         "vlnv": "xilinx.com:ip:xlslice:1.0",
-        "xci_name": "amdc_revd_xlslice_1_0",
+        "xci_name": "amdc_revd_xlslice_0_2",
         "parameters": {
           "DIN_FROM": {
             "value": "1"
@@ -4259,7 +4277,6 @@
       "xlconstant_6_dout": {
         "ports": [
           "xlconstant_6/dout",
-          "amdc_gpio_mux_0/device_out_2",
           "amdc_gpio_mux_0/device_out_3",
           "amdc_gpio_mux_0/device_out_4"
         ]
@@ -4267,7 +4284,8 @@
       "amdc_gpio_mux_0_device_in_1": {
         "ports": [
           "amdc_gpio_mux_0/device_in_1",
-          "xlslice_0/Din"
+          "xlslice_0/Din",
+          "xlslice_1/Din"
         ]
       },
       "xlconstant_7_dout": {
@@ -4276,22 +4294,16 @@
           "xlconcat_2/In1"
         ]
       },
-      "xlslice_0_Dout": {
+      "xlconcat_3_dout": {
         "ports": [
-          "xlslice_0/Dout",
-          "processing_system7_0/CAN0_PHY_RX"
-        ]
-      },
-      "processing_system7_0_CAN0_PHY_TX": {
-        "ports": [
-          "processing_system7_0/CAN0_PHY_TX",
-          "xlslice_1/Din"
-        ]
-      },
-      "xlslice_1_Dout": {
-        "ports": [
-          "xlslice_1/Dout",
+          "xlconcat_3/dout",
           "amdc_gpio_mux_0/device_out_1"
+        ]
+      },
+      "xlconstant_8_dout": {
+        "ports": [
+          "xlconstant_8/dout",
+          "amdc_gpio_mux_0/device_out_2"
         ]
       }
     },

--- a/hw/amdc_revd.bd
+++ b/hw/amdc_revd.bd
@@ -67,7 +67,10 @@
       "amdc_inv_status_mux_0": "",
       "amdc_dac_0": "",
       "xlconstant_6": "",
-      "amdc_gpio_mux_0": ""
+      "amdc_gpio_mux_0": "",
+      "xlslice_0": "",
+      "xlconcat_2": "",
+      "xlconstant_7": ""
     },
     "interface_ports": {
       "DDR": {
@@ -744,7 +747,7 @@
             "value": "666.666687"
           },
           "PCW_ACT_CAN_PERIPHERAL_FREQMHZ": {
-            "value": "10.000000"
+            "value": "100.000000"
           },
           "PCW_ACT_DCI_PERIPHERAL_FREQMHZ": {
             "value": "10.158730"
@@ -759,10 +762,10 @@
             "value": "200.000000"
           },
           "PCW_ACT_FPGA1_PERIPHERAL_FREQMHZ": {
-            "value": "50.000000"
+            "value": "20.000000"
           },
           "PCW_ACT_FPGA2_PERIPHERAL_FREQMHZ": {
-            "value": "8.000000"
+            "value": "10.000000"
           },
           "PCW_ACT_FPGA3_PERIPHERAL_FREQMHZ": {
             "value": "10.000000"
@@ -815,14 +818,38 @@
           "PCW_APU_PERIPHERAL_FREQMHZ": {
             "value": "667"
           },
+          "PCW_CAN0_CAN0_IO": {
+            "value": "EMIO"
+          },
+          "PCW_CAN0_GRP_CLK_ENABLE": {
+            "value": "0"
+          },
+          "PCW_CAN0_PERIPHERAL_ENABLE": {
+            "value": "1"
+          },
+          "PCW_CAN1_CAN1_IO": {
+            "value": "EMIO"
+          },
+          "PCW_CAN1_GRP_CLK_ENABLE": {
+            "value": "0"
+          },
+          "PCW_CAN1_PERIPHERAL_ENABLE": {
+            "value": "1"
+          },
+          "PCW_CAN_PERIPHERAL_FREQMHZ": {
+            "value": "100"
+          },
+          "PCW_CAN_PERIPHERAL_VALID": {
+            "value": "1"
+          },
           "PCW_CLK0_FREQ": {
             "value": "200000000"
           },
           "PCW_CLK1_FREQ": {
-            "value": "50000000"
+            "value": "20000000"
           },
           "PCW_CLK2_FREQ": {
-            "value": "8000000"
+            "value": "10000000"
           },
           "PCW_CLK3_FREQ": {
             "value": "10000000"
@@ -875,6 +902,12 @@
           "PCW_ENET_RESET_SELECT": {
             "value": "Share reset pin"
           },
+          "PCW_EN_CAN0": {
+            "value": "1"
+          },
+          "PCW_EN_CAN1": {
+            "value": "1"
+          },
           "PCW_EN_CLK0_PORT": {
             "value": "1"
           },
@@ -882,12 +915,18 @@
             "value": "1"
           },
           "PCW_EN_CLK2_PORT": {
-            "value": "1"
+            "value": "0"
           },
           "PCW_EN_CLK3_PORT": {
             "value": "0"
           },
           "PCW_EN_DDR": {
+            "value": "1"
+          },
+          "PCW_EN_EMIO_CAN0": {
+            "value": "1"
+          },
+          "PCW_EN_EMIO_CAN1": {
             "value": "1"
           },
           "PCW_EN_EMIO_CD_SDIO1": {
@@ -947,14 +986,11 @@
           "PCW_FCLK_CLK1_BUF": {
             "value": "TRUE"
           },
-          "PCW_FCLK_CLK2_BUF": {
-            "value": "TRUE"
-          },
           "PCW_FPGA0_PERIPHERAL_FREQMHZ": {
             "value": "200"
           },
           "PCW_FPGA1_PERIPHERAL_FREQMHZ": {
-            "value": "50"
+            "value": "20"
           },
           "PCW_FPGA2_PERIPHERAL_FREQMHZ": {
             "value": "8"
@@ -966,9 +1002,6 @@
             "value": "1"
           },
           "PCW_FPGA_FCLK1_ENABLE": {
-            "value": "1"
-          },
-          "PCW_FPGA_FCLK2_ENABLE": {
             "value": "1"
           },
           "PCW_GPIO_EMIO_GPIO_ENABLE": {
@@ -2077,16 +2110,16 @@
               }
             },
             "interface_nets": {
-              "s00_couplers_to_auto_pc": {
-                "interface_ports": [
-                  "S_AXI",
-                  "auto_pc/S_AXI"
-                ]
-              },
               "auto_pc_to_s00_couplers": {
                 "interface_ports": [
                   "M_AXI",
                   "auto_pc/M_AXI"
+                ]
+              },
+              "s00_couplers_to_auto_pc": {
+                "interface_ports": [
+                  "S_AXI",
+                  "auto_pc/S_AXI"
                 ]
               }
             },
@@ -2253,16 +2286,16 @@
               }
             },
             "interface_nets": {
-              "m01_couplers_to_auto_pc": {
-                "interface_ports": [
-                  "S_AXI",
-                  "auto_pc/S_AXI"
-                ]
-              },
               "auto_pc_to_m01_couplers": {
                 "interface_ports": [
                   "M_AXI",
                   "auto_pc/M_AXI"
+                ]
+              },
+              "m01_couplers_to_auto_pc": {
+                "interface_ports": [
+                  "S_AXI",
+                  "auto_pc/S_AXI"
                 ]
               }
             },
@@ -2341,16 +2374,16 @@
               }
             },
             "interface_nets": {
-              "m02_couplers_to_auto_pc": {
-                "interface_ports": [
-                  "S_AXI",
-                  "auto_pc/S_AXI"
-                ]
-              },
               "auto_pc_to_m02_couplers": {
                 "interface_ports": [
                   "M_AXI",
                   "auto_pc/M_AXI"
+                ]
+              },
+              "m02_couplers_to_auto_pc": {
+                "interface_ports": [
+                  "S_AXI",
+                  "auto_pc/S_AXI"
                 ]
               }
             },
@@ -2429,16 +2462,16 @@
               }
             },
             "interface_nets": {
-              "auto_pc_to_m03_couplers": {
-                "interface_ports": [
-                  "M_AXI",
-                  "auto_pc/M_AXI"
-                ]
-              },
               "m03_couplers_to_auto_pc": {
                 "interface_ports": [
                   "S_AXI",
                   "auto_pc/S_AXI"
+                ]
+              },
+              "auto_pc_to_m03_couplers": {
+                "interface_ports": [
+                  "M_AXI",
+                  "auto_pc/M_AXI"
                 ]
               }
             },
@@ -2517,16 +2550,16 @@
               }
             },
             "interface_nets": {
-              "auto_pc_to_m04_couplers": {
-                "interface_ports": [
-                  "M_AXI",
-                  "auto_pc/M_AXI"
-                ]
-              },
               "m04_couplers_to_auto_pc": {
                 "interface_ports": [
                   "S_AXI",
                   "auto_pc/S_AXI"
+                ]
+              },
+              "auto_pc_to_m04_couplers": {
+                "interface_ports": [
+                  "M_AXI",
+                  "auto_pc/M_AXI"
                 ]
               }
             },
@@ -2605,16 +2638,16 @@
               }
             },
             "interface_nets": {
-              "m05_couplers_to_auto_pc": {
-                "interface_ports": [
-                  "S_AXI",
-                  "auto_pc/S_AXI"
-                ]
-              },
               "auto_pc_to_m05_couplers": {
                 "interface_ports": [
                   "M_AXI",
                   "auto_pc/M_AXI"
+                ]
+              },
+              "m05_couplers_to_auto_pc": {
+                "interface_ports": [
+                  "S_AXI",
+                  "auto_pc/S_AXI"
                 ]
               }
             },
@@ -2781,16 +2814,16 @@
               }
             },
             "interface_nets": {
-              "m07_couplers_to_auto_pc": {
-                "interface_ports": [
-                  "S_AXI",
-                  "auto_pc/S_AXI"
-                ]
-              },
               "auto_pc_to_m07_couplers": {
                 "interface_ports": [
                   "M_AXI",
                   "auto_pc/M_AXI"
+                ]
+              },
+              "m07_couplers_to_auto_pc": {
+                "interface_ports": [
+                  "S_AXI",
+                  "auto_pc/S_AXI"
                 ]
               }
             },
@@ -2869,16 +2902,16 @@
               }
             },
             "interface_nets": {
-              "auto_pc_to_m08_couplers": {
-                "interface_ports": [
-                  "M_AXI",
-                  "auto_pc/M_AXI"
-                ]
-              },
               "m08_couplers_to_auto_pc": {
                 "interface_ports": [
                   "S_AXI",
                   "auto_pc/S_AXI"
+                ]
+              },
+              "auto_pc_to_m08_couplers": {
+                "interface_ports": [
+                  "M_AXI",
+                  "auto_pc/M_AXI"
                 ]
               }
             },
@@ -2957,16 +2990,16 @@
               }
             },
             "interface_nets": {
-              "m09_couplers_to_auto_pc": {
-                "interface_ports": [
-                  "S_AXI",
-                  "auto_pc/S_AXI"
-                ]
-              },
               "auto_pc_to_m09_couplers": {
                 "interface_ports": [
                   "M_AXI",
                   "auto_pc/M_AXI"
+                ]
+              },
+              "m09_couplers_to_auto_pc": {
+                "interface_ports": [
+                  "S_AXI",
+                  "auto_pc/S_AXI"
                 ]
               }
             },
@@ -3149,16 +3182,16 @@
           }
         },
         "interface_nets": {
-          "m12_couplers_to_ps7_0_axi_periph": {
+          "xbar_to_m00_couplers": {
             "interface_ports": [
-              "M12_AXI",
-              "m12_couplers/M_AXI"
+              "xbar/M00_AXI",
+              "m00_couplers/S_AXI"
             ]
           },
-          "xbar_to_m11_couplers": {
+          "m01_couplers_to_ps7_0_axi_periph": {
             "interface_ports": [
-              "xbar/M11_AXI",
-              "m11_couplers/S_AXI"
+              "M01_AXI",
+              "m01_couplers/M_AXI"
             ]
           },
           "xbar_to_m12_couplers": {
@@ -3167,10 +3200,22 @@
               "m12_couplers/S_AXI"
             ]
           },
-          "xbar_to_m05_couplers": {
+          "s00_couplers_to_xbar": {
             "interface_ports": [
-              "xbar/M05_AXI",
-              "m05_couplers/S_AXI"
+              "s00_couplers/M_AXI",
+              "xbar/S00_AXI"
+            ]
+          },
+          "m00_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M00_AXI",
+              "m00_couplers/M_AXI"
+            ]
+          },
+          "ps7_0_axi_periph_to_s00_couplers": {
+            "interface_ports": [
+              "S00_AXI",
+              "s00_couplers/S_AXI"
             ]
           },
           "m06_couplers_to_ps7_0_axi_periph": {
@@ -3195,6 +3240,72 @@
             "interface_ports": [
               "xbar/M07_AXI",
               "m07_couplers/S_AXI"
+            ]
+          },
+          "m08_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M08_AXI",
+              "m08_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m08_couplers": {
+            "interface_ports": [
+              "xbar/M08_AXI",
+              "m08_couplers/S_AXI"
+            ]
+          },
+          "m09_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M09_AXI",
+              "m09_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m09_couplers": {
+            "interface_ports": [
+              "xbar/M09_AXI",
+              "m09_couplers/S_AXI"
+            ]
+          },
+          "m10_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M10_AXI",
+              "m10_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m10_couplers": {
+            "interface_ports": [
+              "xbar/M10_AXI",
+              "m10_couplers/S_AXI"
+            ]
+          },
+          "m11_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M11_AXI",
+              "m11_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m11_couplers": {
+            "interface_ports": [
+              "xbar/M11_AXI",
+              "m11_couplers/S_AXI"
+            ]
+          },
+          "m12_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M12_AXI",
+              "m12_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m01_couplers": {
+            "interface_ports": [
+              "xbar/M01_AXI",
+              "m01_couplers/S_AXI"
+            ]
+          },
+          "m02_couplers_to_ps7_0_axi_periph": {
+            "interface_ports": [
+              "M02_AXI",
+              "m02_couplers/M_AXI"
             ]
           },
           "m03_couplers_to_ps7_0_axi_periph": {
@@ -3233,88 +3344,10 @@
               "m05_couplers/M_AXI"
             ]
           },
-          "m09_couplers_to_ps7_0_axi_periph": {
+          "xbar_to_m05_couplers": {
             "interface_ports": [
-              "M09_AXI",
-              "m09_couplers/M_AXI"
-            ]
-          },
-          "xbar_to_m08_couplers": {
-            "interface_ports": [
-              "xbar/M08_AXI",
-              "m08_couplers/S_AXI"
-            ]
-          },
-          "xbar_to_m09_couplers": {
-            "interface_ports": [
-              "xbar/M09_AXI",
-              "m09_couplers/S_AXI"
-            ]
-          },
-          "m10_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M10_AXI",
-              "m10_couplers/M_AXI"
-            ]
-          },
-          "m08_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M08_AXI",
-              "m08_couplers/M_AXI"
-            ]
-          },
-          "xbar_to_m10_couplers": {
-            "interface_ports": [
-              "xbar/M10_AXI",
-              "m10_couplers/S_AXI"
-            ]
-          },
-          "m11_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M11_AXI",
-              "m11_couplers/M_AXI"
-            ]
-          },
-          "ps7_0_axi_periph_to_s00_couplers": {
-            "interface_ports": [
-              "S00_AXI",
-              "s00_couplers/S_AXI"
-            ]
-          },
-          "s00_couplers_to_xbar": {
-            "interface_ports": [
-              "s00_couplers/M_AXI",
-              "xbar/S00_AXI"
-            ]
-          },
-          "m00_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M00_AXI",
-              "m00_couplers/M_AXI"
-            ]
-          },
-          "xbar_to_m00_couplers": {
-            "interface_ports": [
-              "xbar/M00_AXI",
-              "m00_couplers/S_AXI"
-            ]
-          },
-          "m01_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M01_AXI",
-              "m01_couplers/M_AXI"
-            ]
-          },
-          "xbar_to_m01_couplers": {
-            "interface_ports": [
-              "xbar/M01_AXI",
-              "m01_couplers/S_AXI"
-            ]
-          },
-          "m02_couplers_to_ps7_0_axi_periph": {
-            "interface_ports": [
-              "M02_AXI",
-              "m02_couplers/M_AXI"
+              "xbar/M05_AXI",
+              "m05_couplers/S_AXI"
             ]
           }
         },
@@ -3640,7 +3673,7 @@
       },
       "xlconstant_6": {
         "vlnv": "xilinx.com:ip:xlconstant:1.1",
-        "xci_name": "amdc_revd_xlconstant_0_1",
+        "xci_name": "amdc_revd_xlconstant_6_1",
         "parameters": {
           "CONST_VAL": {
             "value": "0"
@@ -3653,49 +3686,41 @@
       "amdc_gpio_mux_0": {
         "vlnv": "xilinx.com:user:amdc_gpio_mux:1.0",
         "xci_name": "amdc_revd_amdc_gpio_mux_0_1"
+      },
+      "xlslice_0": {
+        "vlnv": "xilinx.com:ip:xlslice:1.0",
+        "xci_name": "amdc_revd_xlslice_0_0",
+        "parameters": {
+          "DIN_FROM": {
+            "value": "0"
+          },
+          "DIN_TO": {
+            "value": "0"
+          },
+          "DIN_WIDTH": {
+            "value": "2"
+          }
+        }
+      },
+      "xlconcat_2": {
+        "vlnv": "xilinx.com:ip:xlconcat:2.1",
+        "xci_name": "amdc_revd_xlconcat_2_0"
+      },
+      "xlconstant_7": {
+        "vlnv": "xilinx.com:ip:xlconstant:1.1",
+        "xci_name": "amdc_revd_xlconstant_1_1",
+        "parameters": {
+          "CONST_VAL": {
+            "value": "0"
+          }
+        }
       }
     },
     "interface_nets": {
-      "ps7_0_axi_periph_M01_AXI": {
-        "interface_ports": [
-          "ps7_0_axi_periph/M01_AXI",
-          "amdc_encoder_0/S00_AXI"
-        ]
-      },
       "processing_system7_0_DDR": {
         "interface_ports": [
           "DDR",
           "processing_system7_0/DDR"
-        ]
-      },
-      "ps7_0_axi_periph_M05_AXI": {
-        "interface_ports": [
-          "ps7_0_axi_periph/M05_AXI",
-          "amdc_leds_0/S00_AXI"
-        ]
-      },
-      "ps7_0_axi_periph_M02_AXI": {
-        "interface_ports": [
-          "ps7_0_axi_periph/M02_AXI",
-          "amdc_inverters_0/S00_AXI"
-        ]
-      },
-      "ps7_0_axi_periph_M06_AXI": {
-        "interface_ports": [
-          "ps7_0_axi_periph/M06_AXI",
-          "amdc_pwm_mux_0/S00_AXI"
-        ]
-      },
-      "ps7_0_axi_periph_M00_AXI": {
-        "interface_ports": [
-          "ps7_0_axi_periph/M00_AXI",
-          "amdc_adc_0/S00_AXI"
-        ]
-      },
-      "processing_system7_0_FIXED_IO": {
-        "interface_ports": [
-          "FIXED_IO",
-          "processing_system7_0/FIXED_IO"
         ]
       },
       "ps7_0_axi_periph_M07_AXI": {
@@ -3704,22 +3729,34 @@
           "amdc_inv_status_mux_0/S00_AXI"
         ]
       },
+      "ps7_0_axi_periph_M03_AXI": {
+        "interface_ports": [
+          "ps7_0_axi_periph/M03_AXI",
+          "control_timer_0/S_AXI"
+        ]
+      },
       "ps7_0_axi_periph_M08_AXI": {
         "interface_ports": [
           "ps7_0_axi_periph/M08_AXI",
           "amdc_dac_0/S00_AXI"
         ]
       },
-      "ps7_0_axi_periph_M09_AXI": {
+      "ps7_0_axi_periph_M06_AXI": {
         "interface_ports": [
-          "ps7_0_axi_periph/M09_AXI",
-          "amdc_gpio_mux_0/S00_AXI"
+          "ps7_0_axi_periph/M06_AXI",
+          "amdc_pwm_mux_0/S00_AXI"
         ]
       },
-      "ps7_0_axi_periph_M04_AXI": {
+      "ps7_0_axi_periph_M01_AXI": {
         "interface_ports": [
-          "ps7_0_axi_periph/M04_AXI",
-          "control_timer_1/S_AXI"
+          "ps7_0_axi_periph/M01_AXI",
+          "amdc_encoder_0/S00_AXI"
+        ]
+      },
+      "processing_system7_0_FIXED_IO": {
+        "interface_ports": [
+          "FIXED_IO",
+          "processing_system7_0/FIXED_IO"
         ]
       },
       "processing_system7_0_M_AXI_GP0": {
@@ -3728,10 +3765,34 @@
           "ps7_0_axi_periph/S00_AXI"
         ]
       },
-      "ps7_0_axi_periph_M03_AXI": {
+      "ps7_0_axi_periph_M04_AXI": {
         "interface_ports": [
-          "ps7_0_axi_periph/M03_AXI",
-          "control_timer_0/S_AXI"
+          "ps7_0_axi_periph/M04_AXI",
+          "control_timer_1/S_AXI"
+        ]
+      },
+      "ps7_0_axi_periph_M02_AXI": {
+        "interface_ports": [
+          "ps7_0_axi_periph/M02_AXI",
+          "amdc_inverters_0/S00_AXI"
+        ]
+      },
+      "ps7_0_axi_periph_M00_AXI": {
+        "interface_ports": [
+          "ps7_0_axi_periph/M00_AXI",
+          "amdc_adc_0/S00_AXI"
+        ]
+      },
+      "ps7_0_axi_periph_M09_AXI": {
+        "interface_ports": [
+          "ps7_0_axi_periph/M09_AXI",
+          "amdc_gpio_mux_0/S00_AXI"
+        ]
+      },
+      "ps7_0_axi_periph_M05_AXI": {
+        "interface_ports": [
+          "ps7_0_axi_periph/M05_AXI",
+          "amdc_leds_0/S00_AXI"
         ]
       }
     },
@@ -4181,8 +4242,25 @@
           "xlconstant_6/dout",
           "amdc_gpio_mux_0/device_out_2",
           "amdc_gpio_mux_0/device_out_3",
-          "amdc_gpio_mux_0/device_out_4",
+          "amdc_gpio_mux_0/device_out_4"
+        ]
+      },
+      "amdc_gpio_mux_0_device_in_1": {
+        "ports": [
+          "amdc_gpio_mux_0/device_in_1",
+          "xlslice_0/Din"
+        ]
+      },
+      "xlconcat_2_dout": {
+        "ports": [
+          "xlconcat_2/dout",
           "amdc_gpio_mux_0/device_out_1"
+        ]
+      },
+      "xlconstant_7_dout": {
+        "ports": [
+          "xlconstant_7/dout",
+          "xlconcat_2/In1"
         ]
       }
     },

--- a/sdk/bare/common/drv/bsp.c
+++ b/sdk/bare/common/drv/bsp.c
@@ -87,7 +87,7 @@ void bsp_init(void)
     sts_mux_init();
     gpio_mux_init();
     dac_init();
-    can_init();
+    can_init(0);
 #endif
 
 #if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_C

--- a/sdk/bare/common/drv/bsp.c
+++ b/sdk/bare/common/drv/bsp.c
@@ -11,7 +11,6 @@
 
 #include "drv/analog.h"
 #include "drv/bsp.h"
-# include "drv/can.h"
 #include "drv/cpu_timer.h"
 #include "drv/dac.h"
 #include "drv/encoder.h"
@@ -24,6 +23,10 @@
 #include "sys/defines.h"
 #include <stdio.h>
 
+#ifdef APP_CAN
+#include "drv/can.h"
+#endif
+
 #if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_C
 #include "drv/gpio.h"
 #include "drv/io.h"
@@ -34,7 +37,6 @@
 #include "drv/gpio_mux.h"
 #include "drv/led.h"
 #include "drv/sts_mux.h"
-
 #endif
 
 void bsp_init(void)
@@ -87,7 +89,11 @@ void bsp_init(void)
     sts_mux_init();
     gpio_mux_init();
     dac_init();
+#endif
+
+#ifdef APP_CAN
     can_init(0);
+    can_init(1);
 #endif
 
 #if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_C

--- a/sdk/bare/common/drv/bsp.c
+++ b/sdk/bare/common/drv/bsp.c
@@ -11,6 +11,7 @@
 
 #include "drv/analog.h"
 #include "drv/bsp.h"
+# include "drv/can.h"
 #include "drv/cpu_timer.h"
 #include "drv/dac.h"
 #include "drv/encoder.h"
@@ -86,6 +87,7 @@ void bsp_init(void)
     sts_mux_init();
     gpio_mux_init();
     dac_init();
+    can_init();
 #endif
 
 #if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_C

--- a/sdk/bare/common/drv/can.c
+++ b/sdk/bare/common/drv/can.c
@@ -1,13 +1,12 @@
 #include "drv/uart.h"
-#include "sys/defines.h"
-#include "xparameters.h"
-#include "xcanps.h"
 #include "gpio_mux.h"
+#include "sys/defines.h"
+#include "xcanps.h"
+#include "xparameters.h"
 #include <stdio.h>
 
 #define CAN0_DEVICE_ID XPAR_XCANPS_0_DEVICE_ID
 #define CAN1_DEVICE_ID XPAR_XCANPS_1_DEVICE_ID
-
 
 // Maximum CAN frame length in words.
 #define XCANPS_MAX_FRAME_SIZE_IN_WORDS (XCANPS_MAX_FRAME_SIZE / sizeof(u32))
@@ -16,7 +15,7 @@
 #define FRAME_DATA_LENGTH 8
 
 // Message Id Constant
-#define MESSAGE_ID	2000
+#define MESSAGE_ID 2000
 
 /*
  * The Baud Rate Prescaler Register (BRPR) and Bit Timing Register (BTR)
@@ -32,9 +31,9 @@
  frequency
  * is 24 MHz.
  */
-#define DEFAULT_BTR_SYNCJUMPWIDTH		3
-#define DEFAULT_BTR_SECOND_TIMESEGMENT	2
-#define DEFAULT_BTR_FIRST_TIMESEGMENT	15
+#define DEFAULT_BTR_SYNCJUMPWIDTH 	   3
+#define DEFAULT_BTR_SECOND_TIMESEGMENT 2
+#define DEFAULT_BTR_FIRST_TIMESEGMENT  15
 
 /*
  * The Baud rate Prescalar value in the Baud Rate Prescaler Register (BRPR)
@@ -43,7 +42,7 @@
  * This value is for a 40 Kbps baudrate assuming the CAN input clock frequency
  * is 24 MHz.
  */
-#define DEFAULT_BAUD_PRESCALAR	29
+#define DEFAULT_BAUD_PRESCALAR 29
 
 static u32 TxFrame[XCANPS_MAX_FRAME_SIZE_IN_WORDS];
 static u32 RxFrame[XCANPS_MAX_FRAME_SIZE_IN_WORDS];
@@ -58,14 +57,12 @@ static XCanPs *CanPs;
 // Set the mode of the CAN device
 int can_setmode(uint32_t mode)
 {
-
 	XCanPs *CanInstPtr = CanPs;
 	uint32_t currMode = XCanPs_GetMode(CanInstPtr);
 	if (currMode == XCANPS_MODE_LOOPBACK && mode != XCANPS_MODE_CONFIG) {
 		print("\nCAN peripheral currently in loopback mode. Can only enter config mode from here.");
 		return FAILURE;
-	}
-	else if (currMode == XCANPS_MODE_NORMAL && mode != XCANPS_MODE_SLEEP && mode != XCANPS_MODE_CONFIG){
+	} else if (currMode == XCANPS_MODE_NORMAL && mode != XCANPS_MODE_SLEEP && mode != XCANPS_MODE_CONFIG){
 		print("\nCAN peripheral currently in normal mode. Can only enter config or sleep mode from here.");
 		return FAILURE;
 	}
@@ -73,7 +70,8 @@ int can_setmode(uint32_t mode)
 	XCanPs_EnterMode(CanInstPtr, mode);
 
 	// Wait to reach specified mode, should happen instantaneously
-	while(XCanPs_GetMode(CanInstPtr) != mode);
+	while(XCanPs_GetMode(CanInstPtr) != mode)
+		;
 	return SUCCESS;
 }
 

--- a/sdk/bare/common/drv/can.c
+++ b/sdk/bare/common/drv/can.c
@@ -156,6 +156,32 @@ int can_send(uint8_t* packet, int num_bytes)
 	return Status;
 }
 
+// Print latest can packet received
+int can_print()
+{
+	u8 *FramePtr;
+	int Status;
+	int Index;
+
+	XCanPs *CanInstPtr = &CanPs;
+
+	// Wait until a frame is received
+	while (XCanPs_IsRxEmpty(CanInstPtr) == TRUE);
+
+	// Receive a frame and verify its contents
+	Status = XCanPs_Recv(CanInstPtr, RxFrame);
+
+	if (Status == XST_SUCCESS) {
+		print("Latest CAN packet is: ");
+		FramePtr = (u8 *)(&RxFrame[2]);
+		for (Index = 0; Index < FRAME_DATA_LENGTH; Index++) {
+			print(*FramePtr);
+			FramePtr++;
+		}
+	}
+	return Status;
+}
+
 // Check packet received in loopback mode is correct
 int can_checkpacket()
 {

--- a/sdk/bare/common/drv/can.c
+++ b/sdk/bare/common/drv/can.c
@@ -78,23 +78,23 @@ int can_setmode(uint32_t mode)
 // Set Baud Rate Prescalar Register (BRPR)
 int can_setbaud(int rate)
 {
-  int Status;
-  XCanPs *CanInstPtr = CanPs;
+	int Status;
+	XCanPs *CanInstPtr = CanPs;
 
-  // Ensure CAN peripheral in config mode
-  if (XCanPs_GetMode(CanInstPtr) != XCANPS_MODE_CONFIG) {
-    print("\nMust be in config mode to set baud rate prescalar register");
-	return FAILURE;
-  }
+	// Ensure CAN peripheral in config mode
+	if (XCanPs_GetMode(CanInstPtr) != XCANPS_MODE_CONFIG) {
+		print("\nMust be in config mode to set baud rate prescalar register");
+		return FAILURE;
+	}
 
-  // Initialize to default baud rate
-  if (!rate)
-    rate = DEFAULT_BAUD_PRESCALAR;
-  Status = XCanPs_SetBaudRatePrescaler(CanInstPtr, rate);
+	// Initialize to default baud rate
+	if (!rate)
+		rate = DEFAULT_BAUD_PRESCALAR;
+	Status = XCanPs_SetBaudRatePrescaler(CanInstPtr, rate);
 
-  if (Status != XST_SUCCESS)
-    return FAILURE;
-  return SUCCESS;
+	if (Status != XST_SUCCESS)
+		return FAILURE;
+	return SUCCESS;
 }
 
 // Set Bit Timing Register (BTR)

--- a/sdk/bare/common/drv/can.c
+++ b/sdk/bare/common/drv/can.c
@@ -272,7 +272,7 @@ int can_print()
 
 	XCanPs *CanInstPtr = CanPs;
 
-	// Wait until a frame is received
+	// Check if a frame is empty
 	if (XCanPs_IsRxEmpty(CanInstPtr) == TRUE) {
 		printf("Currently there isn't a packet in the RxFIFO, try again in a bit!\n");
 		return FAILURE;

--- a/sdk/bare/common/drv/can.c
+++ b/sdk/bare/common/drv/can.c
@@ -6,7 +6,6 @@
 #include "xparameters.h"
 #include <stdio.h>
 
-
 #define CAN0_DEVICE_ID XPAR_XCANPS_0_DEVICE_ID
 #define CAN1_DEVICE_ID XPAR_XCANPS_1_DEVICE_ID
 

--- a/sdk/bare/common/drv/can.c
+++ b/sdk/bare/common/drv/can.c
@@ -1,0 +1,215 @@
+#include "drv/uart.h"
+#include "sys/defines.h"
+#include "xparameters.h"
+#include "xcanps.h"
+#include <stdio.h>
+
+#define CAN_DEVICE_ID XPAR_XCANPS_0_DEVICE_ID
+
+/*
+ * Maximum CAN frame length in words.
+ */
+#define XCANPS_MAX_FRAME_SIZE_IN_WORDS (XCANPS_MAX_FRAME_SIZE / sizeof(u32))
+
+#define FRAME_DATA_LENGTH 		8  /* Frame Data field length */
+
+/*
+ * Message Id Constant.
+ */
+#define MESSAGE_ID			2000
+
+/*
+ * The Baud Rate Prescaler Register (BRPR) and Bit Timing Register (BTR)
+ * are setup such that CAN baud rate equals 40Kbps, assuming that the
+ * the CAN clock is 24MHz. The user needs to modify these values based on
+ * the desired baud rate and the CAN clock frequency. For more information
+ * see the CAN 2.0A, CAN 2.0B, ISO 11898-1 specifications.
+ */
+
+/*
+ * Timing parameters to be set in the Bit Timing Register (BTR).
+ * These values are for a 40 Kbps baudrate assuming the CAN input clock
+ frequency
+ * is 24 MHz.
+ */
+#define TEST_BTR_SYNCJUMPWIDTH		3
+#define TEST_BTR_SECOND_TIMESEGMENT	2
+#define TEST_BTR_FIRST_TIMESEGMENT	15
+
+/*
+ * The Baud rate Prescalar value in the Baud Rate Prescaler Register (BRPR)
+ * needs to be set based on the input clock  frequency to the CAN core and
+ * the desired CAN baud rate.
+ * This value is for a 40 Kbps baudrate assuming the CAN input clock frequency
+ * is 24 MHz.
+ */
+#define TEST_BRPR_BAUD_PRESCALAR	29
+
+static u32 TxFrame[XCANPS_MAX_FRAME_SIZE_IN_WORDS];
+static u32 RxFrame[XCANPS_MAX_FRAME_SIZE_IN_WORDS];
+
+// Instance of the CAN Device
+XCanPs CanPs;
+
+// Set the mode of the CAN device
+int can_setmode(uint32_t mode) {
+
+	XCanPs *CanInstPtr = &CanPs;
+	XCanPs_EnterMode(CanInstPtr, mode);
+	while(XCanPs_GetMode(CanInstPtr) != mode);
+	return XST_SUCCESS;
+}
+
+// Set Baud Rate Prescalar Register (BRPR)
+int can_setbaud(int rate) {
+	XCanPs *CanInstPtr = &CanPs;
+	// Initialize to default baud rate
+	if (!rate)
+		rate = TEST_BRPR_BAUD_PRESCALAR;
+	XCanPs_SetBaudRatePrescaler(CanInstPtr, rate);
+	return XST_SUCCESS;
+}
+
+// Set Bit Timing Register (BTR)
+int can_set_btr(int jump_width, int first_time, int second_time) {
+	XCanPs *CanInstPtr = &CanPs;
+	// Initialize to defaults provided by Xilinx
+	if (!jump_width && !first_time && !second_time)
+		XCanPs_SetBitTiming(CanInstPtr, TEST_BTR_SYNCJUMPWIDTH,
+						TEST_BTR_SECOND_TIMESEGMENT,
+						TEST_BTR_FIRST_TIMESEGMENT);
+	else
+		XCanPs_SetBitTiming(CanInstPtr, jump_width,
+						first_time,
+						second_time);
+	return XST_SUCCESS;
+}
+
+// Initialize the CAN device, default settings
+int can_init(void)
+{
+	XCanPs *CanInstPtr = &CanPs;
+	u16 DeviceId = CAN_DEVICE_ID;
+
+	int Status;
+	XCanPs_Config *Config;
+
+	// Initialize the CAN driver so that it's ready to use
+	// Look up the configuration in the config table, then initialize it
+	Config = XCanPs_LookupConfig(DeviceId);
+	if (NULL == Config) {
+		return FAILURE;
+	}
+
+	Status = XCanPs_CfgInitialize(CanInstPtr, Config, Config->BaseAddr);
+	if (Status != XST_SUCCESS) {
+		return FAILURE;
+	}
+
+	// Run self-test on the device, which verifies basic sanity of the
+	// device and the driver
+	Status = XCanPs_SelfTest(CanInstPtr);
+	if (Status != XST_SUCCESS) {
+		return FAILURE;
+	}
+
+	// Enter Configuration Mode so that we can setup Baud Rate Precalar
+	// Register (BRPR) and Bit Timing Register (BTR).
+	can_setmode(XCANPS_MODE_CONFIG);
+
+	// Set Baud Rate Prescalar Register (BRPR) and
+	// Bit Timing Register (BTR)
+	can_setbaud(TEST_BRPR_BAUD_PRESCALAR);
+	can_set_btr(TEST_BTR_SYNCJUMPWIDTH, TEST_BTR_SECOND_TIMESEGMENT, TEST_BTR_FIRST_TIMESEGMENT);
+
+	// Enter Normal Mode to use CAN peripheral via API calls
+	can_setmode(XCANPS_MODE_NORMAL);
+
+	return XST_SUCCESS;
+}
+
+// Send a CAN packet
+int can_send(uint8_t* packet, int num_bytes)
+{
+	u8 *FramePtr;
+	int Index;
+	int Status;
+	XCanPs *CanInstPtr = &CanPs;
+
+	// Create correct values for Identifier and Data Length Code Register
+	TxFrame[0] = (u32)XCanPs_CreateIdValue((u32)MESSAGE_ID, 0, 0, 0, 0);
+	TxFrame[1] = (u32)XCanPs_CreateDlcValue((u32)FRAME_DATA_LENGTH);
+
+	// Populate the TX FIFO with CAN packet to send
+	FramePtr = (u8 *)(&TxFrame[2]);
+	for (Index = 0; Index < num_bytes; Index++) {
+		*FramePtr++ = (u8)*packet;
+	}
+
+
+	// Wait until TX FIFO has room
+	while (XCanPs_IsTxFifoFull(CanInstPtr) == TRUE);
+
+	// Send the frame
+	Status = XCanPs_Send(CanInstPtr, TxFrame);
+
+	return Status;
+}
+
+// Check packet received in loopback mode is correct
+int can_checkpacket()
+{
+	u8 *FramePtr;
+	int Status;
+	int Index;
+
+	XCanPs *CanInstPtr = &CanPs;
+
+	// Wait until a frame is received
+	while (XCanPs_IsRxEmpty(CanInstPtr) == TRUE);
+
+	// Receive a frame and verify its contents
+	Status = XCanPs_Recv(CanInstPtr, RxFrame);
+	if (Status == XST_SUCCESS) {
+		// Verify Identifier and Data Length Code
+		if (RxFrame[0] !=
+			(u32)XCanPs_CreateIdValue((u32)MESSAGE_ID, 0, 0, 0, 0))
+			return XST_LOOPBACK_ERROR;
+
+		if ((RxFrame[1] & ~XCANPS_DLCR_TIMESTAMP_MASK) != TxFrame[1])
+			return XST_LOOPBACK_ERROR;
+
+		// Verify Data field contents
+		FramePtr = (u8 *)(&RxFrame[2]);
+		for (Index = 0; Index < FRAME_DATA_LENGTH; Index++) {
+			if (*FramePtr++ != (u8)Index) {
+				return XST_LOOPBACK_ERROR;
+			}
+		}
+	}
+
+	return Status;
+}
+
+// Run a sanity check loopback test
+int can_loopback_test()
+{
+
+	int Status;
+	uint8_t packet[FRAME_DATA_LENGTH];
+
+	// CAN Packet Populated
+	int i;
+	for (i = 0; i < FRAME_DATA_LENGTH; i++) {
+		packet[i] = i;
+	}
+
+	Status = can_send(packet, FRAME_DATA_LENGTH);
+	if (Status != XST_SUCCESS) {
+		return FAILURE;
+	}
+
+	Status = can_checkpacket();
+	return Status;
+
+}

--- a/sdk/bare/common/drv/can.c
+++ b/sdk/bare/common/drv/can.c
@@ -78,23 +78,23 @@ int can_setmode(uint32_t mode)
 // Set Baud Rate Prescalar Register (BRPR)
 int can_setbaud(int rate)
 {
-	int Status;
-	XCanPs *CanInstPtr = CanPs;
+  int Status;
+  XCanPs *CanInstPtr = CanPs;
 
-	// Ensure CAN peripheral in config mode
-	if (XCanPs_GetMode(CanInstPtr) != XCANPS_MODE_CONFIG) {
-		print("\nMust be in config mode to set baud rate prescalar register");
-		return FAILURE;
-	}
+  // Ensure CAN peripheral in config mode
+  if (XCanPs_GetMode(CanInstPtr) != XCANPS_MODE_CONFIG) {
+    print("\nMust be in config mode to set baud rate prescalar register");
+	return FAILURE;
+  }
 
-	// Initialize to default baud rate
-	if (!rate)
-		rate = DEFAULT_BAUD_PRESCALAR;
-	Status = XCanPs_SetBaudRatePrescaler(CanInstPtr, rate);
+  // Initialize to default baud rate
+  if (!rate)
+    rate = DEFAULT_BAUD_PRESCALAR;
+  Status = XCanPs_SetBaudRatePrescaler(CanInstPtr, rate);
 
-	if (Status != XST_SUCCESS)
-		return FAILURE;
-	return SUCCESS;
+  if (Status != XST_SUCCESS)
+    return FAILURE;
+  return SUCCESS;
 }
 
 // Set Bit Timing Register (BTR)

--- a/sdk/bare/common/drv/can.c
+++ b/sdk/bare/common/drv/can.c
@@ -1,10 +1,11 @@
+#include "can.h"
 #include "drv/uart.h"
 #include "gpio_mux.h"
 #include "sys/defines.h"
 #include "xcanps.h"
 #include "xparameters.h"
 #include <stdio.h>
-#include "can.h"
+
 
 #define CAN0_DEVICE_ID XPAR_XCANPS_0_DEVICE_ID
 #define CAN1_DEVICE_ID XPAR_XCANPS_1_DEVICE_ID
@@ -28,261 +29,257 @@ static XCanPs *CanPs;
 // Set the mode of the CAN device
 int can_setmode(can_mode_t mode)
 {
-	XCanPs *CanInstPtr = CanPs;
-	uint32_t currMode = XCanPs_GetMode(CanInstPtr);
-	if (currMode == XCANPS_MODE_LOOPBACK && mode != CAN_CONFIG) {
+    XCanPs *CanInstPtr = CanPs;
+    uint32_t currMode = XCanPs_GetMode(CanInstPtr);
+    if (currMode == XCANPS_MODE_LOOPBACK && mode != CAN_CONFIG) {
 #ifdef CAN_DEBUG
-		print("\nCAN peripheral currently in loopback mode. Can only enter config mode from here.");
+        print("\nCAN peripheral currently in loopback mode. Can only enter config mode from here.");
 #endif
-		return FAILURE;
-	} else if (currMode == XCANPS_MODE_NORMAL && mode != CAN_SLEEP && mode != CAN_CONFIG){
+        return FAILURE;
+    } else if (currMode == XCANPS_MODE_NORMAL && mode != CAN_SLEEP && mode != CAN_CONFIG) {
 #ifdef CAN_DEBUG
-		print("\nCAN peripheral currently in normal mode. Can only enter config or sleep mode from here.");
+        print("\nCAN peripheral currently in normal mode. Can only enter config or sleep mode from here.");
 #endif
-		return FAILURE;
-	}
+        return FAILURE;
+    }
 
-	XCanPs_EnterMode(CanInstPtr, mode);
+    XCanPs_EnterMode(CanInstPtr, mode);
 
-	// Wait to reach specified mode, should happen instantaneously
-	while(XCanPs_GetMode(CanInstPtr) != mode);
-	return SUCCESS;
+    // Wait to reach specified mode, should happen instantaneously
+    while (XCanPs_GetMode(CanInstPtr) != mode)
+        ;
+    return SUCCESS;
 }
 
 // Set Baud Rate Prescalar Register (BRPR)
 int can_setbaud(int rate)
 {
-	int Status;
-	XCanPs *CanInstPtr = CanPs;
+    int Status;
+    XCanPs *CanInstPtr = CanPs;
 
-	// Ensure CAN peripheral in config mode
-	if (XCanPs_GetMode(CanInstPtr) != XCANPS_MODE_CONFIG) {
+    // Ensure CAN peripheral in config mode
+    if (XCanPs_GetMode(CanInstPtr) != XCANPS_MODE_CONFIG) {
 #ifdef CAN_DEBUG
-		print("\nMust be in config mode to set baud rate prescalar register");
+        print("\nMust be in config mode to set baud rate prescalar register");
 #endif
-		return FAILURE;
-	}
+        return FAILURE;
+    }
 
-	Status = XCanPs_SetBaudRatePrescaler(CanInstPtr, rate);
+    Status = XCanPs_SetBaudRatePrescaler(CanInstPtr, rate);
 
-	if (Status != XST_SUCCESS)
-		return FAILURE;
-	return SUCCESS;
+    if (Status != XST_SUCCESS)
+        return FAILURE;
+    return SUCCESS;
 }
 
 // Set Bit Timing Register (BTR)
 int can_set_btr(uint8_t sjw, uint8_t ts2, uint8_t ts1)
 {
-	int Status;
-	XCanPs *CanInstPtr = CanPs;
+    int Status;
+    XCanPs *CanInstPtr = CanPs;
 
-	// Ensure CAN peripheral in config mode
-	if (XCanPs_GetMode(CanInstPtr) != XCANPS_MODE_CONFIG) {
+    // Ensure CAN peripheral in config mode
+    if (XCanPs_GetMode(CanInstPtr) != XCANPS_MODE_CONFIG) {
 #ifdef CAN_DEBUG
-		print("\nMust be in config mode to set bit timing register");
+        print("\nMust be in config mode to set bit timing register");
 #endif
-		return FAILURE;
-	}
+        return FAILURE;
+    }
 
-	Status = XCanPs_SetBitTiming(CanInstPtr, sjw, ts2, ts1);
+    Status = XCanPs_SetBitTiming(CanInstPtr, sjw, ts2, ts1);
 
-	if (Status != XST_SUCCESS)
-		return FAILURE;
-	return SUCCESS;
+    if (Status != XST_SUCCESS)
+        return FAILURE;
+    return SUCCESS;
 }
 
 // Set CAN peripheral that we are using currently
 int can_set_peripheral(int device_id)
 {
-	if (device_id != 1 && device_id != 0)
-		return FAILURE;
-	else if (device_id)
-		CanPs = &CanPs1;
-	else
-		CanPs = &CanPs0;
-	return SUCCESS;
+    if (device_id != 1 && device_id != 0)
+        return FAILURE;
+    else if (device_id)
+        CanPs = &CanPs1;
+    else
+        CanPs = &CanPs0;
+    return SUCCESS;
 }
 
 // Initialize the CAN device, default settings
 int can_init(int device_id)
 {
 
-	// Set GPIO Device and Port
-	gpio_mux_set_device(GPIO_PORT1, GPIO_MUX_DEVICE1);
+    // Set GPIO Device and Port
+    gpio_mux_set_device(GPIO_PORT1, GPIO_MUX_DEVICE1);
 
-	XCanPs *CanInstPtr;
-	u16 DeviceId;
+    XCanPs *CanInstPtr;
+    u16 DeviceId;
 
-	// Initialize the user specified CAN peripheral
-	if (device_id != 1 && device_id != 0) {
+    // Initialize the user specified CAN peripheral
+    if (device_id != 1 && device_id != 0) {
 #ifdef CAN_DEBUG
-		printf("device_id can only be 0 or 1\n");
+        printf("device_id can only be 0 or 1\n");
 #endif
-		return FAILURE;
-	}
-	else if(!device_id) {
-		DeviceId = CAN0_DEVICE_ID;
-		CanInstPtr = &CanPs0;
-		CanPs = &CanPs0;
-		printf("CAN0:\tInitializing...\n");
-	}
-	else {
-		DeviceId = CAN1_DEVICE_ID;
-		CanInstPtr = &CanPs1;
-		CanPs = &CanPs1;
-		printf("CAN1:\tInitializing...\n");
-	}
+        return FAILURE;
+    } else if (!device_id) {
+        DeviceId = CAN0_DEVICE_ID;
+        CanInstPtr = &CanPs0;
+        CanPs = &CanPs0;
+        printf("CAN0:\tInitializing...\n");
+    } else {
+        DeviceId = CAN1_DEVICE_ID;
+        CanInstPtr = &CanPs1;
+        CanPs = &CanPs1;
+        printf("CAN1:\tInitializing...\n");
+    }
 
-	int Status;
-	XCanPs_Config *Config;
+    int Status;
+    XCanPs_Config *Config;
 
-	// Initialize the CAN driver so that it's ready to use
-	// Look up the configuration in the config table, then initialize it
-	Config = XCanPs_LookupConfig(DeviceId);
-	if (Config == NULL || CanInstPtr == NULL) {
-		return FAILURE;
-	}
+    // Initialize the CAN driver so that it's ready to use
+    // Look up the configuration in the config table, then initialize it
+    Config = XCanPs_LookupConfig(DeviceId);
+    if (Config == NULL || CanInstPtr == NULL) {
+        return FAILURE;
+    }
 
-	Status = XCanPs_CfgInitialize(CanInstPtr, Config, Config->BaseAddr);
-	if (Status != XST_SUCCESS) {
-		return FAILURE;
-	}
+    Status = XCanPs_CfgInitialize(CanInstPtr, Config, Config->BaseAddr);
+    if (Status != XST_SUCCESS) {
+        return FAILURE;
+    }
 
-	// Run self-test on the device, which verifies basic sanity of the
-	// device and the driver
-	Status = XCanPs_SelfTest(CanInstPtr);
-	if (Status != XST_SUCCESS) {
-		return FAILURE;
-	}
+    // Run self-test on the device, which verifies basic sanity of the
+    // device and the driver
+    Status = XCanPs_SelfTest(CanInstPtr);
+    if (Status != XST_SUCCESS) {
+        return FAILURE;
+    }
 
-	// Enter Configuration Mode so that we can setup Baud Rate Precalar
-	// Register (BRPR) and Bit Timing Register (BTR).
-	Status = can_setmode(XCANPS_MODE_CONFIG);
-	if (Status != SUCCESS)
-		return FAILURE;
+    // Enter Configuration Mode so that we can setup Baud Rate Precalar
+    // Register (BRPR) and Bit Timing Register (BTR).
+    Status = can_setmode(XCANPS_MODE_CONFIG);
+    if (Status != SUCCESS)
+        return FAILURE;
 
-	// Set Baud Rate Prescalar Register (BRPR) and
-	// Bit Timing Register (BTR)
-	Status = can_setbaud(DEFAULT_BAUD_PRESCALAR);
-	if (Status != SUCCESS) {
-		return FAILURE;
-	}
-	Status = can_set_btr(DEFAULT_BTR_SYNCJUMPWIDTH,
-						 DEFAULT_BTR_SECOND_TIMESEGMENT,
-						 DEFAULT_BTR_FIRST_TIMESEGMENT
-						);
+    // Set Baud Rate Prescalar Register (BRPR) and
+    // Bit Timing Register (BTR)
+    Status = can_setbaud(DEFAULT_BAUD_PRESCALAR);
+    if (Status != SUCCESS) {
+        return FAILURE;
+    }
+    Status = can_set_btr(DEFAULT_BTR_SYNCJUMPWIDTH, DEFAULT_BTR_SECOND_TIMESEGMENT, DEFAULT_BTR_FIRST_TIMESEGMENT);
 
-	if (Status != SUCCESS) {
-		return FAILURE;
-	}
+    if (Status != SUCCESS) {
+        return FAILURE;
+    }
 
-	// Enter Normal Mode to use CAN peripheral
-	return can_setmode(XCANPS_MODE_NORMAL);
+    // Enter Normal Mode to use CAN peripheral
+    return can_setmode(XCANPS_MODE_NORMAL);
 }
 
 // Send a CAN packet
 int can_send(can_packet_t *packet)
 {
-	u8 *FramePtr;
-	int i;
-	int Status;
-	XCanPs *CanInstPtr = CanPs;
+    u8 *FramePtr;
+    int i;
+    int Status;
+    XCanPs *CanInstPtr = CanPs;
 
-	// Check that pointer isn't NULL
-	if (packet == NULL) {
+    // Check that pointer isn't NULL
+    if (packet == NULL) {
 #ifdef CAN_DEBUG
-		printf("Packet of data is null, please initialize it!\n");
+        printf("Packet of data is null, please initialize it!\n");
 #endif
-		return FAILURE;
-	}
+        return FAILURE;
+    }
 
-	// Check number of bytes user is sending at once is between 1 to 8
-	if (num_bytes <= 0 || num_bytes > 8) {
+    // Check number of bytes user is sending at once is between 1 to 8
+    if (num_bytes <= 0 || num_bytes > 8) {
 #ifdef CAN_DEBUG
-		printf("Can only send 8 bytes at once!\n");
+        printf("Can only send 8 bytes at once!\n");
 #endif
-		return FAILURE;
-	}
+        return FAILURE;
+    }
 
-	// Populate correct values for Identifier - check Zync 700 Reference Manual for meaning of this info
-	TxFrame[0] = (u32)XCanPs_CreateIdValue((u32)packet->message_id, 0, 0, 0, 0);
+    // Populate correct values for Identifier - check Zync 700 Reference Manual for meaning of this info
+    TxFrame[0] = (u32) XCanPs_CreateIdValue((u32) packet->message_id, 0, 0, 0, 0);
 
-	// Specify number of bytes of data sending
-	TxFrame[1] = (u32)XCanPs_CreateDlcValue((u32)packet->num_bytes);
+    // Specify number of bytes of data sending
+    TxFrame[1] = (u32) XCanPs_CreateDlcValue((u32) packet->num_bytes);
 
-	// Populate the TX FIFO with CAN packet to send
-	FramePtr = (u8 *)(&TxFrame[2]);
-	for (i = 0; i < packet->num_bytes; i++) {
-		*FramePtr++ = (u8)packet->buffer[i];
-	}
+    // Populate the TX FIFO with CAN packet to send
+    FramePtr = (u8 *) (&TxFrame[2]);
+    for (i = 0; i < packet->num_bytes; i++) {
+        *FramePtr++ = (u8) packet->buffer[i];
+    }
 
-	// Check if TxFIFO is full
-	if (XCanPs_IsTxFifoFull(CanInstPtr) == TRUE) {
+    // Check if TxFIFO is full
+    if (XCanPs_IsTxFifoFull(CanInstPtr) == TRUE) {
 #ifdef CAN_DEBUG
-		printf("CAN TxFIFO is full, try sending your data again in a bit!\n");
+        printf("CAN TxFIFO is full, try sending your data again in a bit!\n");
 #endif
-		return FAILURE;
-	}
+        return FAILURE;
+    }
 
-	// Send the frame
-	Status = XCanPs_Send(CanInstPtr, TxFrame);
+    // Send the frame
+    Status = XCanPs_Send(CanInstPtr, TxFrame);
 
-	if (Status != XST_SUCCESS)
-		return FAILURE;
-	return SUCCESS;
+    if (Status != XST_SUCCESS)
+        return FAILURE;
+    return SUCCESS;
 }
 
 // Print latest can packet received
 int can_rcv(can_packet_t *packet)
 {
-	u8 *FramePtr;
-	int Status;
-	int i;
+    u8 *FramePtr;
+    int Status;
+    int i;
 
-	XCanPs *CanInstPtr = CanPs;
+    XCanPs *CanInstPtr = CanPs;
 
-	// Check if a frame is empty
-	if (XCanPs_IsRxEmpty(CanInstPtr) == TRUE) {
+    // Check if a frame is empty
+    if (XCanPs_IsRxEmpty(CanInstPtr) == TRUE) {
 #ifdef CAN_DEBUG
-		printf("Currently there isn't a packet in the RxFIFO, try again in a bit!\n");
+        printf("Currently there isn't a packet in the RxFIFO, try again in a bit!\n");
 #endif
-		return FAILURE;
-	}
+        return FAILURE;
+    }
 
-	// Receive a frame and verify its contents
-	Status = XCanPs_Recv(CanInstPtr, RxFrame);
+    // Receive a frame and verify its contents
+    Status = XCanPs_Recv(CanInstPtr, RxFrame);
 
-	if (Status == XST_SUCCESS) {
-		packet->message_id = (int)(RxFrame[0] >> 21);
-		packet->num_bytes = (int)(RxFrame[1] >> 28);
-		FramePtr = (u8 *)(&RxFrame[2]);
-		for (i = 0; i < packet->num_bytes; i++) {
-			packet->buffer[i] = *FramePtr;
-			FramePtr++;
-		}
-		return SUCCESS;
-	}
-	return FAILURE;
+    if (Status == XST_SUCCESS) {
+        packet->message_id = (int) (RxFrame[0] >> 21);
+        packet->num_bytes = (int) (RxFrame[1] >> 28);
+        FramePtr = (u8 *) (&RxFrame[2]);
+        for (i = 0; i < packet->num_bytes; i++) {
+            packet->buffer[i] = *FramePtr;
+            FramePtr++;
+        }
+        return SUCCESS;
+    }
+    return FAILURE;
 }
 
 // Print mode the CAN peripheral is in, useful for debugging purposes
 void can_print_mode()
 {
 #ifdef CAN_DEBUG
-	XCanPs *CanInstPtr = CanPs;
+    XCanPs *CanInstPtr = CanPs;
 
-	uint32_t mode;
-	mode = XCanPs_GetMode(CanInstPtr);
-	if(mode == XCANPS_MODE_NORMAL)
-		print("\nXCANPS_MODE_NORMAL");
-	else if(mode == XCANPS_MODE_LOOPBACK)
-		print("\nXCANPS_MODE_LOOPBACK");
-	else if(mode == XCANPS_MODE_CONFIG)
-			print("\nXCANPS_MODE_CONFIG");
-	else if(mode == XCANPS_MODE_SLEEP)
-			print("\nXCANPS_MODE_SLEEP");
-	else
-		print("\nOther mode");
+    uint32_t mode;
+    mode = XCanPs_GetMode(CanInstPtr);
+    if (mode == XCANPS_MODE_NORMAL)
+        print("\nXCANPS_MODE_NORMAL");
+    else if (mode == XCANPS_MODE_LOOPBACK)
+        print("\nXCANPS_MODE_LOOPBACK");
+    else if (mode == XCANPS_MODE_CONFIG)
+        print("\nXCANPS_MODE_CONFIG");
+    else if (mode == XCANPS_MODE_SLEEP)
+        print("\nXCANPS_MODE_SLEEP");
+    else
+        print("\nOther mode");
 #endif
 }
 
@@ -290,83 +287,83 @@ void can_print_mode()
 void can_print_peripheral()
 {
 #ifdef CAN_DEBUG
-	if (CanPs == &CanPs0)
-		print("\nCAN 0");
-	else if (CanPs == &CanPs1)
-		print("\nCAN 1");
-	else
-		print("\nCAN peripheral not set properly");
+    if (CanPs == &CanPs0)
+        print("\nCAN 0");
+    else if (CanPs == &CanPs1)
+        print("\nCAN 1");
+    else
+        print("\nCAN peripheral not set properly");
 #endif
 }
 
 // Check packet received in loopback mode is correct
 static int can_checkpacket()
 {
-	u8 *FramePtr;
-	int Status;
-	int Index;
+    u8 *FramePtr;
+    int Status;
+    int Index;
 
-	XCanPs *CanInstPtr = CanPs;
+    XCanPs *CanInstPtr = CanPs;
 
-	// Wait until a frame is received
-	while (XCanPs_IsRxEmpty(CanInstPtr) == TRUE);
+    // Wait until a frame is received
+    while (XCanPs_IsRxEmpty(CanInstPtr) == TRUE)
+        ;
 
-	// Receive a frame and verify its contents
-	Status = XCanPs_Recv(CanInstPtr, RxFrame);
-	if (Status == XST_SUCCESS) {
-		// Verify Identifier and Data Length Code
-		if (RxFrame[0] !=
-			(u32)XCanPs_CreateIdValue((u32)MESSAGE_ID, 0, 0, 0, 0))
-			return XST_LOOPBACK_ERROR;
+    // Receive a frame and verify its contents
+    Status = XCanPs_Recv(CanInstPtr, RxFrame);
+    if (Status == XST_SUCCESS) {
+        // Verify Identifier and Data Length Code
+        if (RxFrame[0] != (u32) XCanPs_CreateIdValue((u32) MESSAGE_ID, 0, 0, 0, 0))
+            return XST_LOOPBACK_ERROR;
 
-		if ((RxFrame[1] & ~XCANPS_DLCR_TIMESTAMP_MASK) != TxFrame[1])
-			return XST_LOOPBACK_ERROR;
+        if ((RxFrame[1] & ~XCANPS_DLCR_TIMESTAMP_MASK) != TxFrame[1])
+            return XST_LOOPBACK_ERROR;
 
-		// Verify Data field contents
-		FramePtr = (u8 *)(&RxFrame[2]);
-		for (Index = 0; Index < FRAME_DATA_LENGTH; Index++) {
-			if (*FramePtr++ != (u8)Index) {
-				return XST_LOOPBACK_ERROR;
-			}
-		}
-	}
+        // Verify Data field contents
+        FramePtr = (u8 *) (&RxFrame[2]);
+        for (Index = 0; Index < FRAME_DATA_LENGTH; Index++) {
+            if (*FramePtr++ != (u8) Index) {
+                return XST_LOOPBACK_ERROR;
+            }
+        }
+    }
 
-	return Status;
+    return Status;
 }
 
 // Run a sanity check loopback test
 int can_loopback_test()
 {
 
-	int Status;
-	uint8_t packet[FRAME_DATA_LENGTH];
+    int Status;
+    uint8_t packet[FRAME_DATA_LENGTH];
 
-	// Check we are in loopback mode
-	uint32_t mode;
-	XCanPs *CanInstPtr = CanPs;
-	mode = XCanPs_GetMode(CanInstPtr);
-	if (mode != XCANPS_MODE_LOOPBACK) {
+    // Check we are in loopback mode
+    uint32_t mode;
+    XCanPs *CanInstPtr = CanPs;
+    mode = XCanPs_GetMode(CanInstPtr);
+    if (mode != XCANPS_MODE_LOOPBACK) {
 #ifdef CAN_DEBUG
-		print("\nNot in loopback mode, can't run self test");
+        print("\nNot in loopback mode, can't run self test");
 #endif
-		return FAILURE;
-	}
+        return FAILURE;
+    }
 
-	// Populate CAN packet
-	int i;
-	for (i = 0; i < FRAME_DATA_LENGTH; i++) {
-		packet[i] = i;
-	}
+    // Populate CAN packet
+    int i;
+    for (i = 0; i < FRAME_DATA_LENGTH; i++) {
+        packet[i] = i;
+    }
 
-	// Send fake packet of data
-	Status = can_send(packet, FRAME_DATA_LENGTH);
-	if (Status != XST_SUCCESS) {
-		return FAILURE;
-	}
+    // Send fake packet of data
+    Status = can_send(packet, FRAME_DATA_LENGTH);
+    if (Status != XST_SUCCESS) {
+        return FAILURE;
+    }
 
-	// Check fake packet of data is received correctly
-	Status = can_checkpacket();
-	if (Status != XST_SUCCESS)
-		return FAILURE;
-	return SUCCESS;
+    // Check fake packet of data is received correctly
+    Status = can_checkpacket();
+    if (Status != XST_SUCCESS)
+        return FAILURE;
+    return SUCCESS;
 }

--- a/sdk/bare/common/drv/can.h
+++ b/sdk/bare/common/drv/can.h
@@ -10,7 +10,7 @@ int can_setmode(uint32_t value);
 int can_setbaud(int rate);
 int can_set_btr(int jump_width, int first_time, int second_time);
 
-int can_send(XCanPs *InstancePtr);
+int can_send(uint8_t* packet, int num_bytes);
 int can_checkpacket(char *msg, int len);
 
 int can_loopback_test();

--- a/sdk/bare/common/drv/can.h
+++ b/sdk/bare/common/drv/can.h
@@ -4,7 +4,6 @@
 #include "xcanps.h"
 #include <stdint.h>
 
-
 /*
  * The Baud Rate Prescaler Register (BRPR) and Bit Timing Register (BTR)
  * are setup such that CAN baud rate equals 40Kbps, assuming that the

--- a/sdk/bare/common/drv/can.h
+++ b/sdk/bare/common/drv/can.h
@@ -11,8 +11,7 @@ int can_setbaud(int rate);
 int can_set_btr(int jump_width, int first_time, int second_time);
 
 int can_send(uint8_t* packet, int num_bytes);
-int can_checkpacket(char *msg, int len);
-
+int can_print();
 int can_loopback_test();
 
 

--- a/sdk/bare/common/drv/can.h
+++ b/sdk/bare/common/drv/can.h
@@ -1,8 +1,9 @@
 #ifndef CAN_H
 #define CAN_H
 
-#include <stdint.h>
 #include "xcanps.h"
+#include <stdint.h>
+
 
 /*
  * The Baud Rate Prescaler Register (BRPR) and Bit Timing Register (BTR)
@@ -18,7 +19,7 @@
  frequency
  * is 24 MHz.
  */
-#define DEFAULT_BTR_SYNCJUMPWIDTH 	   3
+#define DEFAULT_BTR_SYNCJUMPWIDTH      3
 #define DEFAULT_BTR_SECOND_TIMESEGMENT 2
 #define DEFAULT_BTR_FIRST_TIMESEGMENT  15
 
@@ -42,9 +43,9 @@ typedef enum {
 
 // Struct representing an entire CAN Packet
 typedef struct can_packets_t {
-	int message_id;
-	int num_bytes;
-	uint8_t buffer[8];
+    int message_id;
+    int num_bytes;
+    uint8_t buffer[8];
 } can_packet_t;
 
 // Setter methods, useful for configuring the CAN peripheral

--- a/sdk/bare/common/drv/can.h
+++ b/sdk/bare/common/drv/can.h
@@ -4,18 +4,61 @@
 #include <stdint.h>
 #include "xcanps.h"
 
+/*
+ * The Baud Rate Prescaler Register (BRPR) and Bit Timing Register (BTR)
+ * are setup such that CAN baud rate equals 40Kbps, assuming that the
+ * the CAN clock is 24MHz. The user needs to modify these values based on
+ * the desired baud rate and the CAN clock frequency. For more information
+ * see the CAN 2.0A, CAN 2.0B, ISO 11898-1 specifications.
+ */
+
+/*
+ * Timing parameters to be set in the Bit Timing Register (BTR).
+ * These values are for a 40 Kbps baudrate assuming the CAN input clock
+ frequency
+ * is 24 MHz.
+ */
+#define DEFAULT_BTR_SYNCJUMPWIDTH 	   3
+#define DEFAULT_BTR_SECOND_TIMESEGMENT 2
+#define DEFAULT_BTR_FIRST_TIMESEGMENT  15
+
+/*
+ * The Baud rate Prescalar value in the Baud Rate Prescaler Register (BRPR)
+ * needs to be set based on the input clock  frequency to the CAN core and
+ * the desired CAN baud rate.
+ * This value is for a 40 Kbps baudrate assuming the CAN input clock frequency
+ * is 24 MHz.
+ */
+#define DEFAULT_BAUD_PRESCALAR 29
+
+// Different CAN modes
+typedef enum {
+    CAN_CONFIG = XCANPS_MODE_CONFIG,
+    CAN_LOOPBACK = XCANPS_MODE_LOOPBACK,
+    CAN_NORMAL = XCANPS_MODE_NORMAL,
+    CAN_SLEEP = XCANPS_MODE_SLEEP,
+    CAN_SNOOP = XCANPS_MODE_SNOOP,
+} can_mode_t;
+
+// Struct representing an entire CAN Packet
+typedef struct can_packets_t {
+	int message_id;
+	int num_bytes;
+	uint8_t buffer[8];
+} can_packet_t;
+
 // Setter methods, useful for configuring the CAN peripheral
-int can_setmode(uint32_t value);
+int can_setmode(can_mode_t MODE);
 int can_setbaud(int rate);
-int can_set_btr(int jump_width, int first_time, int second_time);
+int can_set_btr(uint8_t sjw, uint8_t ts1, uint8_t ts2);
 int can_set_peripheral(int device_id);
 
 // Initialize the CAN peripheral
-int can_init(int);
+int can_init(int device_id);
 
 // Send and get CAN packets
-int can_send(uint8_t* packet, int num_bytes);
-int can_print();
+int can_send(can_packet_t *packet);
+int can_rcv(can_packet_t *packet);
 
 // Useful debugging functionality
 void can_print_mode();

--- a/sdk/bare/common/drv/can.h
+++ b/sdk/bare/common/drv/can.h
@@ -4,16 +4,24 @@
 #include <stdint.h>
 #include "xcanps.h"
 
-int can_init(int);
-
+// Setter methods, useful for configuring the CAN peripheral
 int can_setmode(uint32_t value);
 int can_setbaud(int rate);
 int can_set_btr(int jump_width, int first_time, int second_time);
+int can_set_peripheral(int device_id);
 
+// Initialize the CAN peripheral
+int can_init(int);
+
+// Send and get CAN packets
 int can_send(uint8_t* packet, int num_bytes);
-void can_print_mode();
 int can_print();
-int can_loopback_test();
 
+// Useful debugging functionality
+void can_print_mode();
+void can_print_peripheral();
+
+// Sanity check that hardware working
+int can_loopback_test();
 
 #endif // CAN_H

--- a/sdk/bare/common/drv/can.h
+++ b/sdk/bare/common/drv/can.h
@@ -1,0 +1,19 @@
+#ifndef CAN_H
+#define CAN_H
+
+#include <stdint.h>
+#include "xcanps.h"
+
+int can_init(void);
+
+int can_setmode(uint32_t value);
+int can_setbaud(int rate);
+int can_set_btr(int jump_width, int first_time, int second_time);
+
+int can_send(XCanPs *InstancePtr);
+int can_checkpacket(char *msg, int len);
+
+int can_loopback_test();
+
+
+#endif // CAN_H

--- a/sdk/bare/common/drv/can.h
+++ b/sdk/bare/common/drv/can.h
@@ -15,24 +15,29 @@
 /*
  * Timing parameters to be set in the Bit Timing Register (BTR).
  * These values are for a 500 Kbps baudrate assuming the CAN input clock frequency
- * is 200 MHz.
+ * is 24 MHz.
  *
- * The value of BTR register after using these defaults is 0x1C
+ * The value of BTR register after using these defaults is 0x1C. According to the Zynq-7000
+ * Reference Manual, the actual value is one more than the value written to the register.
+ * Thus, we write a value of 12 and 1 for the first and second time segment, respectively,
+ * to have an actual value of 13 and 2.
  */
 #define DEFAULT_BTR_SYNCJUMPWIDTH      3
-#define DEFAULT_BTR_SECOND_TIMESEGMENT 2
-#define DEFAULT_BTR_FIRST_TIMESEGMENT  15
+#define DEFAULT_BTR_SECOND_TIMESEGMENT 1
+#define DEFAULT_BTR_FIRST_TIMESEGMENT  12
 
 /*
  * The Baud rate Prescalar value in the Baud Rate Prescaler Register (BRPR)
  * needs to be set based on the input clock  frequency to the CAN core and
  * the desired CAN baud rate.
  * This value is for a 500 Kbps baudrate assuming the CAN input clock frequency
- * is 200 MHz.
+ * is 24 MHz.
  *
- * The value of the BRPR after using this default is 0x18
+ * The value of the BRPR after using this default is 0x02. According to the Zync-7000
+ * Reference Manual, the actual value is one more than the value written to the register.
+ * Thus, we write a value of 2 to the register, but the actual value is 3, which it should be.
  */
-#define DEFAULT_BAUD_PRESCALAR 25
+#define DEFAULT_BAUD_PRESCALAR 2
 
 // Different CAN modes
 typedef enum {

--- a/sdk/bare/common/drv/can.h
+++ b/sdk/bare/common/drv/can.h
@@ -6,17 +6,18 @@
 
 /*
  * The Baud Rate Prescaler Register (BRPR) and Bit Timing Register (BTR)
- * are setup such that CAN baud rate equals 40Kbps, assuming that the
- * the CAN clock is 24MHz. The user needs to modify these values based on
+ * are setup such that CAN baud rate equals 500 Kbps, assuming that the
+ * the CAN clock is 200 MHz. The user needs to modify these values based on
  * the desired baud rate and the CAN clock frequency. For more information
  * see the CAN 2.0A, CAN 2.0B, ISO 11898-1 specifications.
  */
 
 /*
  * Timing parameters to be set in the Bit Timing Register (BTR).
- * These values are for a 40 Kbps baudrate assuming the CAN input clock
- frequency
- * is 24 MHz.
+ * These values are for a 500 Kbps baudrate assuming the CAN input clock frequency
+ * is 200 MHz.
+ *
+ * The value of BTR register after using these defaults is 0x1C
  */
 #define DEFAULT_BTR_SYNCJUMPWIDTH      3
 #define DEFAULT_BTR_SECOND_TIMESEGMENT 2
@@ -26,10 +27,12 @@
  * The Baud rate Prescalar value in the Baud Rate Prescaler Register (BRPR)
  * needs to be set based on the input clock  frequency to the CAN core and
  * the desired CAN baud rate.
- * This value is for a 40 Kbps baudrate assuming the CAN input clock frequency
- * is 24 MHz.
+ * This value is for a 500 Kbps baudrate assuming the CAN input clock frequency
+ * is 200 MHz.
+ *
+ * The value of the BRPR after using this default is 0x18
  */
-#define DEFAULT_BAUD_PRESCALAR 29
+#define DEFAULT_BAUD_PRESCALAR 25
 
 // Different CAN modes
 typedef enum {

--- a/sdk/bare/common/drv/can.h
+++ b/sdk/bare/common/drv/can.h
@@ -4,13 +4,14 @@
 #include <stdint.h>
 #include "xcanps.h"
 
-int can_init(void);
+int can_init(int);
 
 int can_setmode(uint32_t value);
 int can_setbaud(int rate);
 int can_set_btr(int jump_width, int first_time, int second_time);
 
 int can_send(uint8_t* packet, int num_bytes);
+void can_print_mode();
 int can_print();
 int can_loopback_test();
 

--- a/sdk/bare/common/drv/docs/CAN-Expansion-Board.md
+++ b/sdk/bare/common/drv/docs/CAN-Expansion-Board.md
@@ -1,0 +1,116 @@
+# CAN Expansion Board Drivers
+
+## Table of Contents
+- [Purpose of Document](#purpose-of-document)
+- [Using the CAN Board](#using-the-can-board)
+- [What is Provided](#what-is-provided)
+- [Hardware Discussion](#hardware-discussion)
+- [Files](#files)
+- [API Interface](#api-interface)
+## Purpose of Document
+This document highlights the architecture of the CAN firmware targetting the AMDC hardware board REV D such that it can interface with devices on a CAN bus using the CAN expansion board. Specifically, the document describes the drivers thar are used to control and configure the CAN peripherals baked into the Zync-7000 SoC.
+
+## Using the CAN Board
+In order to use the CAN board, you will need an `AMDC` board (targetted to `REVD`), a `CAN` board, and one GPIO Expansion cable (high density DB15 cable). Plug in the `CAN` board to the `AMDC` board via the high density cable.
+
+## What is Provided
+The following are provided for the development of the CAN firmware.
+1. Two CAN peripherals baked into the silicon of the Zync-7000 SoC
+2. CAN IP Block for Xilinx FPGA (although a license is required, more on this [below](#hardware-discussion))
+3. Drivers to use these CAN peripherals
+
+Given that the drivers are already provided, the API interface is simply a wrapper built on top of the given drivers to abstract the low-level register details from users of the CAN board.
+
+## Hardware Discussion
+Before discussing the actual firmware, let's take a closer look at the hardware provided. As mentioned above, there are two options: 
+1. the CAN peripherals baked into the silicon of the Zync-7000
+2. the CAN IP block for the FPGA provided by Xilinx. 
+
+The latter option was the preferred option such that pins on the processor don't have to be used up by the CAN peripheral, however, after an initial attempt to generate a bitstream using the CAN IP blocks, a failure was reported because the Severson Group doesn't have a license in order to use the IP block. Thus, the first option was used instead.
+
+One problem to get around is that the `GPIO` Expansion signals are electrically connected to the FPGA. Thus, we had to somehow use the CAN peripheral on the DSP, but send the signal through the FPGA to the correct pins. Luckily, there is a way to do this exaxt operation by specifying in Vivado that the pins of the CAN peripheral are EMIO pins such that the signal is sent through the AXI interface to the FPGA. By doing so, we can route `CAN_TX` and `CAN_RX` through the FPGA to the `GPIO` Expansion ports on the `AMDC`.
+
+## Files
+All files for the CAN drivers are in the driver directory ([`common/drv/`](github.com/Severson-Group/AMDC-Firmware/tree/develop/sdk/bare/common/drv)).
+```
+drv/
+|-- can.c
+|-- can.h
+```
+
+## API Interface
+As mentioned, the firmware written is built on top of the provided CAN drivers with the goal of abstracting low-level details and creating an easy-to-use API interface. Note that we repeatedly state the phrase "the current CAN peripheral in use" below. As mentioned above, there are two CAN periphals baked into the silicon of the DSP: `CAN0` and `CAN1`. Users of the API can use either peripheral and set the current CAN peripheral in use via an API call. 
+
+Below is a description of each API function...
+
+### Configuring the CAN Peripherals
+```
+int can_setmode(uin32_t mode);
+```
+Sets the mode of the current CAN peripheral in use, options include config, normal, sleep, loopback, and snoop. The parameter `mode` is of type `uint32_t` and can be any of the following macros (that are found in `xcanps.h`): 
+- `XCANPS_MODE_CONFIG`
+- `XCANPS_MODE_NORMAL`
+- `XCANPS_MODE_SLEEP`
+- `XCANPS_MODE_LOOPBACK`
+- `XCANPS_MODE_SNOOP`
+
+Note that if the current mode of the CAN peripheral is `XCANPS_MODE_LOOPBACK` and the user attempts to go to any other mode other than `XCANPS_MODE_CONFIG`, a `FAILURE` is returned. Similarly, if the CAN peripheral is in `XCANPS_MODE_NORMAL` and the user attempts to go to either `XCANPS_MODE_LOOPBACK` or `XCANPS_MODE_SNOOP`, a `FAILURE` is returned. These restrictions are specified in the Zync-7000 Reference Manual, Chapter 18.
+```
+int can_setbaud(int rate);
+```
+Sets the baud rate register of the current CAN peripheral in use to the user specified `rate`. To set the baud rate to the defaults (hardcoded into the CAN drivers as macros), simply pass call `can_setbaud(0)`. Note that the CAN periphal must be in `XCANPS_MODE_CONFIG` before attempting to change the baud rate register.
+
+```
+int can_set_btr(int jump_width, int first_time, int second_time);
+```
+Sets the bit timing register bits of the current CAN peripheral in use to the user specified inputs. To set these bits to defaults (hardcoded into the CAN drivers as macros), simply call `can_setbtr(0,0,0)`. Note that the CAN periphal must be in `XCANPS_MODE_CONFIG` before attempting to change the bit timing register.
+```
+int can_set_peripheral(int device_id);
+```
+Sets the current CAN peripheral in use, either `CAN0` or `CAN1`. The parameter `device_id` can be either `0` or `1`. 
+
+Note that this API function is only necessary to use if the user initialized both CAN peripherals via the `can_init()` API function. If only one CAN peripheral was initialized, the one that was initialized is automatically the current one in use. 
+```
+int can_init(int device_id);
+```
+Initializes the specified CAN peripheral. This includes activating the CAN peripheral, setting the baud rate an bit timing register to default options, and running a self-test on the peripheral to verify its alive and working. The parameter `device_id` is the CAN peripheral to initialize and can either be 0 or 1. 
+
+As mentioned in the `can_set_peripheral()` description, the peripheral that is initialized is automatically set to the current CAN peripheral in use. 
+
+### Using the CAN Peripherals
+```
+int can_send(uint8_t *packet, int num_bytes);
+```
+Sends 8 bit packets of data on the CAN bus. The number of packets sent provided by the user via `num_bytes`. The parameter `*packet` is a pointer to the current packet of data to be sent. The parameter `num_bytes` is the number of bytes to send. 
+
+Note that because the `AMDC` system firmware utilizes a cooperative scheduler, this driver simply checks whether the `TxFIFO` buffer is full upon the time when the user is attempting to send packets of data on the `CAN` bus. If the `FIFO` is full, then a `FAILURE` is returned with a print statement communicating to the user the scenario that occured and possible suggestions. 
+
+```
+int can_print();
+```
+Prints the latest data the CAN peripheral has received in the `RxFIFO` buffer. 
+
+Note that because the `AMDC` system firmware utilizes a cooperative scheduler, this driver simply checks whether the `RxFIFO` is empty upon the time when the user is attempting to view the most recent sent data on the `CAN` bus. If the `FIFO` is empty, then a `FAILURE` is returned with a printe statement communicating to the user the scneario that occured and possible suggestions.
+### Debugging CAN Peripherals
+These drivers have been written for debugging purposes during development, but can be useful for users during utilization of the API to debug the state of the `CAN` peripherals.
+```
+void can_print_mode();
+```
+Prints the mode of the current CAN peripheral in use. One of 5 modes will be printed:
+- `XCANPS_MODE_CONFIG`
+- `XCANPS_MODE_NORMAL`
+- `XCANPS_MODE_SLEEP`
+- `XCANPS_MODE_LOOPBACK`
+- `XCANPS_MODE_SNOOP`
+```
+void can_print_peripheral();
+```
+Prints which CAN peripheral is in use. Either `CAN0` or `CAN1` is printed.
+```
+int can_loopback_test();
+```
+Runs a lopoback test within the PicoZed SoM such that data is sent via the `TxFIFO` buffer from the Zync-7000 to the Xilinx FPGA and received back in the `RxFIFO` buffer. This data is validated that it was indeed the data that was originally sent. 
+
+## Final Word
+
+Final word, there is a user app that is implemented to illustrate how to use the CAN API via the CLI. While this user app isn't actually something that is necessarily helpful for any researchers, that is you wouldn't use the CAN peripheral via the command line, it is meant to provide guidance on how to use the interface. This user app can be found in `common/usr/can`.

--- a/sdk/bare/common/usr/can/app_can.c
+++ b/sdk/bare/common/usr/can/app_can.c
@@ -1,0 +1,16 @@
+#ifdef APP_CAN
+
+#include "usr/can/app_can.h"
+#include "usr/can/cmd/cmd_can.h"
+#include "usr/can/task_can.h"
+
+void app_can_init(void)
+{
+    // Registers the "can" command with the system
+    cmd_can_register();
+
+    // Initialize the can task with the system
+    task_can_init();
+}
+
+#endif // APP_CAN

--- a/sdk/bare/common/usr/can/app_can.h
+++ b/sdk/bare/common/usr/can/app_can.h
@@ -1,0 +1,6 @@
+#ifndef APP_CAN_H
+#define APP_CAN_H
+
+void app_can_init(void);
+
+#endif // APP_CAN_H

--- a/sdk/bare/common/usr/can/cmd/cmd_can.c
+++ b/sdk/bare/common/usr/can/cmd/cmd_can.c
@@ -22,9 +22,11 @@ static command_help_t cmd_help[] = {
     { "send <number of bytes>", "Send a predefined message with specified number of bytes" },
 	{ "print", "Prints latest message"},
 	{ "print mode", "Prints  mode of CAN peripheral"},
+	{ "print peripheral", "Prints current CAN peripheral in use"},
 	{ "setmode <mode>", "Set CAN mode {loopback, sleep, config, normal}"},
 	{ "setbaud <baudrate>", "Set CAN baudrate (type 0 for default)"},
 	{ "set btr <jump> <first time> <second time>", "Set CAN bit timing register (type 0s for default)"},
+	{ "peripheral <device_id>", "Set CAN peripheral in use: either 0 or 1"},
 };
 
 void cmd_can_register(void)
@@ -118,6 +120,16 @@ int cmd_can(int argc, char **argv)
 		return CMD_SUCCESS;
 	}
 
+	// Handle 'print peripheral' sub-command
+	//
+	// First, verify correct number of arguments (3)
+	// Second, verify correct arguments
+	if (argc == 3 && strcmp("print", argv[1]) == 0 && strcmp("peripheral", argv[2]) == 0) {
+		if (task_can_print_peripheral() != SUCCESS)
+			return CMD_FAILURE;
+		return CMD_SUCCESS;
+	}
+
 	// Handle 'setmode' sub-command
 	//
 	// First, verify correct number of arguments (3)
@@ -162,7 +174,7 @@ int cmd_can(int argc, char **argv)
 	// First, verify correct number of argumnets (6)
 	// Second, verify second argument is "set" and
 	// Third, verify third argument is "btr"
-	if (argc == 6 && strcmp("set", argv[1]) == 0 && strcmp("btr", argv[1]) == 0) {
+	if (argc == 6 && strcmp("set", argv[1]) == 0 && strcmp("btr", argv[2]) == 0) {
 		int jump;
 		int first_time;
 		int second_time;
@@ -175,6 +187,17 @@ int cmd_can(int argc, char **argv)
 		return CMD_SUCCESS;
 	}
 
+	// Handle 'peripheral' sub-command
+	//
+	// First, verify correct number of arguments 3)
+	// Second, verify second argument is "peripheral"
+	if (argc == 3 && strcmp("peripheral", argv[1]) == 0) {
+		int device_id;
+		sscanf(argv[2], "%i", &device_id);
+		if (task_can_set_peripheral(device_id) != SUCCESS)
+			return CMD_FAILURE;
+		return CMD_SUCCESS;
+	}
 
 
     // At any point, if an error is detected in given input command,

--- a/sdk/bare/common/usr/can/cmd/cmd_can.c
+++ b/sdk/bare/common/usr/can/cmd/cmd_can.c
@@ -1,0 +1,151 @@
+#ifdef APP_CAN
+
+#include "usr/can/cmd/cmd_can.h"
+#include "sys/commands.h"
+#include "sys/debug.h"
+#include "sys/defines.h"
+#include "sys/util.h"
+#include "usr/can/task_can.h"
+#include "xcanps.h"
+#include <stdlib.h>
+#include <string.h>
+
+// Stores command entry for command system module
+static command_entry_t cmd_entry;
+
+// Defines help content displayed for this command
+// when user types "help" at command prompt
+static command_help_t cmd_help[] = {
+    { "init", "Start task" },
+    { "deinit", "Stop task" },
+	{ "selftest", "Run test message in loopback mode"},
+    { "send <message>", "Send message" },
+	{ "print message", "Prints latest message"},
+	{ "setmode <mode>", "Set CAN mode {loopback, sleep, config, normal}"},
+	{ "setbaud <baudrate>", "Set CAN baudrate (type 0 for default)"},
+	{ "set btr <jump> <first time> <second time>", "Set CAN bit timing register (type 0s for default)"},
+};
+
+void cmd_can_register(void)
+{
+    // Populate the command entry block
+    //
+    // Here is where you define the base command string: "can"
+    // and what function is called to handle command
+	commands_cmd_init(&cmd_entry, "can", "CAN application commands", cmd_help, ARRAY_SIZE(cmd_help), cmd_can);
+
+    // Register the command with the system
+    commands_cmd_register(&cmd_entry);
+}
+
+
+int cmd_can(int argc, char **argv)
+{
+    // This function is called every time the user types "can"
+    // followed by a space and any number of characters.
+
+    // Handle 'init' sub-command
+    //
+    // First, verify correct number of arguments (2)
+    // Second, verify second argument is "init"
+    if (argc == 2 && strcmp("init", argv[1]) == 0) {
+        if (task_can_init() != SUCCESS) {
+            return CMD_FAILURE;
+        }
+
+        return CMD_SUCCESS;
+    }
+
+    // Handle 'deinit' sub-command
+    //
+    // First, verify correct number of arguments (2)
+    // Second, verify second argument is "deinit"
+    if (argc == 2 && strcmp("deinit", argv[1]) == 0) {
+        if (task_can_deinit() != SUCCESS) {
+            return CMD_FAILURE;
+        }
+
+        return CMD_SUCCESS;
+    }
+
+    // Handle 'selftest' sub-command
+	//
+	// First, verify correct number of arguments (2)
+	// Second, verify second argument is "test"
+	if (argc == 2 && strcmp("selftest", argv[1]) == 0) {
+		if (task_can_loopback_test() != SUCCESS) {
+			return CMD_FAILURE;
+		}
+		return CMD_SUCCESS;
+	}
+
+	// Handle 'setmode' sub-command
+	//
+	// First, verify correct number of arguments (3)
+	// Second, verify second argument is "setmode"
+	if (argc == 3 && strcmp("setmode", argv[1]) == 0) {
+		if (strcmp("loopback", argv[2]) == 0) {
+			if (task_can_setmode(XCANPS_MODE_LOOPBACK) != SUCCESS)
+				return CMD_FAILURE;
+		}
+		else if (strcmp("normal", argv[2]) == 0) {
+			if (task_can_setmode(XCANPS_MODE_NORMAL) != SUCCESS)
+				return CMD_FAILURE;
+		}
+		else if (strcmp("config", argv[2]) == 0) {
+			if (task_can_setmode(XCANPS_MODE_CONFIG) != SUCCESS)
+				return CMD_FAILURE;
+		}
+		else if (strcmp("sleep", argv[2]) == 0) {
+			if (task_can_setmode(XCANPS_MODE_SLEEP) != SUCCESS)
+				return CMD_FAILURE;
+		}
+		return CMD_SUCCESS;
+	}
+
+	// Handle 'setbaud' sub-command
+	//
+	// First, verify correct number of arguments (3)
+	// Second, verify second argument is "setbaud"
+	if (argc == 3 && strcmp("setbaud", argv[1]) == 0) {
+		 int baud;
+		 sscanf(argv[2], "%i", &baud);
+		 if (task_can_setbaud(baud) != SUCCESS) {
+			 return CMD_FAILURE;
+		 }
+		 return CMD_SUCCESS;
+	}
+
+	// Handle 'set btr' sub-command
+	//
+	// First, verify correct number of argumnets (6)
+	// Second, verify second argument is "set" and
+	// Third, verify third argument is "btr"
+	if (argc == 6 && strcmp("set", argv[1]) == 0 && strcmp("btr", argv[1]) == 0) {
+		int jump;
+		int first_time;
+		int second_time;
+		sscanf(argv[2], "%i", &jump);
+		sscanf(argv[2], "%i", &first_time);
+		sscanf(argv[2], "%i", &second_time);
+		if (task_can_set_btr(jump, first_time, second_time) != SUCCESS) {
+			return CMD_FAILURE;
+		}
+		return CMD_SUCCESS;
+	}
+
+
+
+    // At any point, if an error is detected in given input command,
+    // simply return an error code (defined in sys/defines.h)
+    //
+    // The return statement below is used to catch all user input which
+    // didn't match the if statements above. In general, to handle commands,
+    // assume they are invalid. Only after checking if each argument is
+    // valid should you trust them.
+    //
+    // Common error return values are: FAILURE, INVALID_ARGUMENTS
+    return CMD_INVALID_ARGUMENTS;
+}
+
+#endif // APP_CAN

--- a/sdk/bare/common/usr/can/cmd/cmd_can.c
+++ b/sdk/bare/common/usr/can/cmd/cmd_can.c
@@ -21,6 +21,7 @@ static command_help_t cmd_help[] = {
 	{ "selftest", "Run test message in loopback mode"},
     { "send <number of bytes>", "Send a predefined message with specified number of bytes" },
 	{ "print", "Prints latest message"},
+	{ "print mode", "Prints  mode of CAN peripheral"},
 	{ "setmode <mode>", "Set CAN mode {loopback, sleep, config, normal}"},
 	{ "setbaud <baudrate>", "Set CAN baudrate (type 0 for default)"},
 	{ "set btr <jump> <first time> <second time>", "Set CAN bit timing register (type 0s for default)"},
@@ -107,6 +108,16 @@ int cmd_can(int argc, char **argv)
 		return CMD_SUCCESS;
 	}
 
+	// Handle 'print mode' sub-command
+	//
+	// First, verify correct number of arguments (3)
+	// Second, verify correct arguments
+	if (argc == 3 && strcmp("print", argv[1]) == 0 && strcmp("mode", argv[2]) == 0) {
+		if (task_can_print_mode() != SUCCESS)
+			return CMD_FAILURE;
+		return CMD_SUCCESS;
+	}
+
 	// Handle 'setmode' sub-command
 	//
 	// First, verify correct number of arguments (3)
@@ -126,8 +137,10 @@ int cmd_can(int argc, char **argv)
 		}
 		else if (strcmp("sleep", argv[2]) == 0) {
 			if (task_can_setmode(XCANPS_MODE_SLEEP) != SUCCESS)
-				return CMD_FAILURE;
+				return CMD_INVALID_ARGUMENTS;
 		}
+		else
+			return CMD_FAILURE;
 		return CMD_SUCCESS;
 	}
 

--- a/sdk/bare/common/usr/can/cmd/cmd_can.c
+++ b/sdk/bare/common/usr/can/cmd/cmd_can.c
@@ -18,15 +18,15 @@ static command_entry_t cmd_entry;
 static command_help_t cmd_help[] = {
     { "init", "Start task" },
     { "deinit", "Stop task" },
-	{ "selftest", "Run test message in loopback mode"},
+    { "selftest", "Run test message in loopback mode" },
     { "send <number of bytes>", "Send a predefined message with specified number of bytes" },
-	{ "print", "Prints latest message"},
-	{ "print mode", "Prints  mode of CAN peripheral"},
-	{ "print peripheral", "Prints current CAN peripheral in use"},
-	{ "setmode <mode>", "Set CAN mode {loopback, sleep, config, normal}"},
-	{ "setbaud <baudrate>", "Set CAN baudrate (type 0 for default)"},
-	{ "set btr <jump> <first time> <second time>", "Set CAN bit timing register (type 0s for default)"},
-	{ "peripheral <device_id>", "Set CAN peripheral in use: either 0 or 1"},
+    { "print", "Prints latest message" },
+    { "print mode", "Prints  mode of CAN peripheral" },
+    { "print peripheral", "Prints current CAN peripheral in use" },
+    { "setmode <mode>", "Set CAN mode {loopback, sleep, config, normal}" },
+    { "setbaud <baudrate>", "Set CAN baudrate (type 0 for default)" },
+    { "set btr <jump> <first time> <second time>", "Set CAN bit timing register (type 0s for default)" },
+    { "peripheral <device_id>", "Set CAN peripheral in use: either 0 or 1" },
 };
 
 void cmd_can_register(void)
@@ -35,12 +35,11 @@ void cmd_can_register(void)
     //
     // Here is where you define the base command string: "can"
     // and what function is called to handle command
-	commands_cmd_init(&cmd_entry, "can", "CAN application commands", cmd_help, ARRAY_SIZE(cmd_help), cmd_can);
+    commands_cmd_init(&cmd_entry, "can", "CAN application commands", cmd_help, ARRAY_SIZE(cmd_help), cmd_can);
 
     // Register the command with the system
     commands_cmd_register(&cmd_entry);
 }
-
 
 int cmd_can(int argc, char **argv)
 {
@@ -72,133 +71,127 @@ int cmd_can(int argc, char **argv)
     }
 
     // Handle 'selftest' sub-command
-	//
-	// First, verify correct number of arguments (2)
-	// Second, verify second argument is "test"
-	if (argc == 2 && strcmp("selftest", argv[1]) == 0) {
-		if (task_can_loopback_test() != SUCCESS) {
-			return CMD_FAILURE;
-		}
-		return CMD_SUCCESS;
-	}
+    //
+    // First, verify correct number of arguments (2)
+    // Second, verify second argument is "test"
+    if (argc == 2 && strcmp("selftest", argv[1]) == 0) {
+        if (task_can_loopback_test() != SUCCESS) {
+            return CMD_FAILURE;
+        }
+        return CMD_SUCCESS;
+    }
 
-	// Handle 'send' sub-command
-	//
-	// First, verify correct number of arguments (4)
-	// Second, verify second argument is "send"
-	if (argc == 3 && strcmp("send", argv[1]) == 0) {
-		int num_bytes;
-		sscanf(argv[2], "%i", &num_bytes);
-		uint8_t packet[num_bytes];
-		int i;
-		for (i = 0; i < num_bytes; i++) {
-			packet[i] = i;
-		}
-		if (task_can_sendmessage(packet, num_bytes) != SUCCESS)
-			return CMD_FAILURE;
-		return CMD_SUCCESS;
+    // Handle 'send' sub-command
+    //
+    // First, verify correct number of arguments (4)
+    // Second, verify second argument is "send"
+    if (argc == 3 && strcmp("send", argv[1]) == 0) {
+        int num_bytes;
+        sscanf(argv[2], "%i", &num_bytes);
+        uint8_t packet[num_bytes];
+        int i;
+        for (i = 0; i < num_bytes; i++) {
+            packet[i] = i;
+        }
+        if (task_can_sendmessage(packet, num_bytes) != SUCCESS)
+            return CMD_FAILURE;
+        return CMD_SUCCESS;
+    }
 
-	}
+    // Handle 'print' sub-command
+    //
+    // First, verify correct number of argument (2)
+    // Second, verify second argument is "print"
+    if (argc == 2 && strcmp("print", argv[1]) == 0) {
+        if (task_can_print() != SUCCESS)
+            return CMD_FAILURE;
+        return CMD_SUCCESS;
+    }
 
-	// Handle 'print' sub-command
-	//
-	// First, verify correct number of argument (2)
-	// Second, verify second argument is "print"
-	if (argc == 2 && strcmp("print", argv[1]) == 0) {
-		if (task_can_print() != SUCCESS)
-			return CMD_FAILURE;
-		return CMD_SUCCESS;
-	}
+    // Handle 'print mode' sub-command
+    //
+    // First, verify correct number of arguments (3)
+    // Second, verify correct arguments
+    if (argc == 3 && strcmp("print", argv[1]) == 0 && strcmp("mode", argv[2]) == 0) {
+        if (task_can_print_mode() != SUCCESS)
+            return CMD_FAILURE;
+        return CMD_SUCCESS;
+    }
 
-	// Handle 'print mode' sub-command
-	//
-	// First, verify correct number of arguments (3)
-	// Second, verify correct arguments
-	if (argc == 3 && strcmp("print", argv[1]) == 0 && strcmp("mode", argv[2]) == 0) {
-		if (task_can_print_mode() != SUCCESS)
-			return CMD_FAILURE;
-		return CMD_SUCCESS;
-	}
+    // Handle 'print peripheral' sub-command
+    //
+    // First, verify correct number of arguments (3)
+    // Second, verify correct arguments
+    if (argc == 3 && strcmp("print", argv[1]) == 0 && strcmp("peripheral", argv[2]) == 0) {
+        if (task_can_print_peripheral() != SUCCESS)
+            return CMD_FAILURE;
+        return CMD_SUCCESS;
+    }
 
-	// Handle 'print peripheral' sub-command
-	//
-	// First, verify correct number of arguments (3)
-	// Second, verify correct arguments
-	if (argc == 3 && strcmp("print", argv[1]) == 0 && strcmp("peripheral", argv[2]) == 0) {
-		if (task_can_print_peripheral() != SUCCESS)
-			return CMD_FAILURE;
-		return CMD_SUCCESS;
-	}
+    // Handle 'setmode' sub-command
+    //
+    // First, verify correct number of arguments (3)
+    // Second, verify second argument is "setmode"
+    if (argc == 3 && strcmp("setmode", argv[1]) == 0) {
+        if (strcmp("loopback", argv[2]) == 0) {
+            if (task_can_setmode(XCANPS_MODE_LOOPBACK) != SUCCESS)
+                return CMD_FAILURE;
+        } else if (strcmp("normal", argv[2]) == 0) {
+            if (task_can_setmode(XCANPS_MODE_NORMAL) != SUCCESS)
+                return CMD_FAILURE;
+        } else if (strcmp("config", argv[2]) == 0) {
+            if (task_can_setmode(XCANPS_MODE_CONFIG) != SUCCESS)
+                return CMD_FAILURE;
+        } else if (strcmp("sleep", argv[2]) == 0) {
+            if (task_can_setmode(XCANPS_MODE_SLEEP) != SUCCESS)
+                return CMD_INVALID_ARGUMENTS;
+        } else
+            return CMD_FAILURE;
+        return CMD_SUCCESS;
+    }
 
-	// Handle 'setmode' sub-command
-	//
-	// First, verify correct number of arguments (3)
-	// Second, verify second argument is "setmode"
-	if (argc == 3 && strcmp("setmode", argv[1]) == 0) {
-		if (strcmp("loopback", argv[2]) == 0) {
-			if (task_can_setmode(XCANPS_MODE_LOOPBACK) != SUCCESS)
-				return CMD_FAILURE;
-		}
-		else if (strcmp("normal", argv[2]) == 0) {
-			if (task_can_setmode(XCANPS_MODE_NORMAL) != SUCCESS)
-				return CMD_FAILURE;
-		}
-		else if (strcmp("config", argv[2]) == 0) {
-			if (task_can_setmode(XCANPS_MODE_CONFIG) != SUCCESS)
-				return CMD_FAILURE;
-		}
-		else if (strcmp("sleep", argv[2]) == 0) {
-			if (task_can_setmode(XCANPS_MODE_SLEEP) != SUCCESS)
-				return CMD_INVALID_ARGUMENTS;
-		}
-		else
-			return CMD_FAILURE;
-		return CMD_SUCCESS;
-	}
+    // Handle 'setbaud' sub-command
+    //
+    // First, verify correct number of arguments (3)
+    // Second, verify second argument is "setbaud"
+    if (argc == 3 && strcmp("setbaud", argv[1]) == 0) {
+        int baud;
+        sscanf(argv[2], "%i", &baud);
+        if (task_can_setbaud(baud) != SUCCESS) {
+            return CMD_FAILURE;
+        }
+        return CMD_SUCCESS;
+    }
 
-	// Handle 'setbaud' sub-command
-	//
-	// First, verify correct number of arguments (3)
-	// Second, verify second argument is "setbaud"
-	if (argc == 3 && strcmp("setbaud", argv[1]) == 0) {
-		 int baud;
-		 sscanf(argv[2], "%i", &baud);
-		 if (task_can_setbaud(baud) != SUCCESS) {
-			 return CMD_FAILURE;
-		 }
-		 return CMD_SUCCESS;
-	}
+    // Handle 'set btr' sub-command
+    //
+    // First, verify correct number of argumnets (6)
+    // Second, verify second argument is "set" and
+    // Third, verify third argument is "btr"
+    if (argc == 6 && strcmp("set", argv[1]) == 0 && strcmp("btr", argv[2]) == 0) {
+        int jump;
+        int first_time;
+        int second_time;
+        sscanf(argv[2], "%i", &jump);
+        sscanf(argv[2], "%i", &first_time);
+        sscanf(argv[2], "%i", &second_time);
+        if (task_can_set_btr(jump, first_time, second_time) != SUCCESS) {
+            return CMD_FAILURE;
+        }
+        return CMD_SUCCESS;
+    }
 
-	// Handle 'set btr' sub-command
-	//
-	// First, verify correct number of argumnets (6)
-	// Second, verify second argument is "set" and
-	// Third, verify third argument is "btr"
-	if (argc == 6 && strcmp("set", argv[1]) == 0 && strcmp("btr", argv[2]) == 0) {
-		int jump;
-		int first_time;
-		int second_time;
-		sscanf(argv[2], "%i", &jump);
-		sscanf(argv[2], "%i", &first_time);
-		sscanf(argv[2], "%i", &second_time);
-		if (task_can_set_btr(jump, first_time, second_time) != SUCCESS) {
-			return CMD_FAILURE;
-		}
-		return CMD_SUCCESS;
-	}
-
-	// Handle 'peripheral' sub-command
-	//
-	// First, verify correct number of arguments 3)
-	// Second, verify second argument is "peripheral"
-	if (argc == 3 && strcmp("peripheral", argv[1]) == 0) {
-		int device_id;
-		sscanf(argv[2], "%i", &device_id);
-		if (task_can_set_peripheral(device_id) != SUCCESS)
-			return CMD_FAILURE;
-		return CMD_SUCCESS;
-	}
-
+    // Handle 'peripheral' sub-command
+    //
+    // First, verify correct number of arguments 3)
+    // Second, verify second argument is "peripheral"
+    if (argc == 3 && strcmp("peripheral", argv[1]) == 0) {
+        int device_id;
+        sscanf(argv[2], "%i", &device_id);
+        if (task_can_set_peripheral(device_id) != SUCCESS)
+            return CMD_FAILURE;
+        return CMD_SUCCESS;
+    }
 
     // At any point, if an error is detected in given input command,
     // simply return an error code (defined in sys/defines.h)

--- a/sdk/bare/common/usr/can/cmd/cmd_can.c
+++ b/sdk/bare/common/usr/can/cmd/cmd_can.c
@@ -19,8 +19,8 @@ static command_help_t cmd_help[] = {
     { "init", "Start task" },
     { "deinit", "Stop task" },
 	{ "selftest", "Run test message in loopback mode"},
-    { "send <message>", "Send message" },
-	{ "print message", "Prints latest message"},
+    { "send <number of bytes>", "Send a predefined message with specified number of bytes" },
+	{ "print", "Prints latest message"},
 	{ "setmode <mode>", "Set CAN mode {loopback, sleep, config, normal}"},
 	{ "setbaud <baudrate>", "Set CAN baudrate (type 0 for default)"},
 	{ "set btr <jump> <first time> <second time>", "Set CAN bit timing register (type 0s for default)"},
@@ -76,6 +76,34 @@ int cmd_can(int argc, char **argv)
 		if (task_can_loopback_test() != SUCCESS) {
 			return CMD_FAILURE;
 		}
+		return CMD_SUCCESS;
+	}
+
+	// Handle 'send' sub-command
+	//
+	// First, verify correct number of arguments (4)
+	// Second, verify second argument is "send"
+	if (argc == 3 && strcmp("send", argv[1]) == 0) {
+		int num_bytes;
+		sscanf(argv[2], "%i", &num_bytes);
+		uint8_t packet[num_bytes];
+		int i;
+		for (i = 0; i < num_bytes; i++) {
+			packet[i] = i;
+		}
+		if (task_can_sendmessage(packet, num_bytes) != SUCCESS)
+			return CMD_FAILURE;
+		return CMD_SUCCESS;
+
+	}
+
+	// Handle 'print' sub-command
+	//
+	// First, verify correct number of argument (2)
+	// Second, verify second argument is "print"
+	if (argc == 2 && strcmp("print", argv[1]) == 0) {
+		if (task_can_print() != SUCCESS)
+			return CMD_FAILURE;
 		return CMD_SUCCESS;
 	}
 

--- a/sdk/bare/common/usr/can/cmd/cmd_can.h
+++ b/sdk/bare/common/usr/can/cmd/cmd_can.h
@@ -1,0 +1,10 @@
+#ifndef CMD_CAN_H
+#define CMD_CAN_H
+
+// Called in app init function to register command with system
+void cmd_can_register(void);
+
+// Function called when user types "can" command into command prompt
+int cmd_can(int argc, char **argv);
+
+#endif // CMD_CAN_H

--- a/sdk/bare/common/usr/can/task_can.c
+++ b/sdk/bare/common/usr/can/task_can.c
@@ -1,0 +1,92 @@
+#ifdef APP_CAN
+
+#include "usr/can/task_can.h"
+#include "drv/can.h"
+#include "drv/hardware_targets.h"
+#include "sys/scheduler.h"
+#include "usr/user_config.h"
+#include "xcanps.h"
+#include <stdint.h>
+#include <stdio.h>
+
+// Scheduler TCB which holds task "context"
+static task_control_block_t tcb;
+
+int task_can_init(void)
+{
+    if (scheduler_tcb_is_registered(&tcb)) {
+        return FAILURE;
+    }
+
+    // Fill TCB with parameters
+    scheduler_tcb_init(&tcb, task_can_callback, NULL, "can", TASK_CAN_INTERVAL_USEC);
+
+    // Register task with scheduler
+    return scheduler_tcb_register(&tcb);
+}
+
+int task_can_deinit(void)
+{
+    // Unregister task with scheduler
+    return scheduler_tcb_unregister(&tcb);
+}
+
+int task_can_loopback_test(void) {
+	int Status;
+	Status = can_loopback_test();
+	if (Status != SUCCESS) {
+		return FAILURE;
+	}
+	return SUCCESS;
+}
+
+int task_can_sendframe()
+{
+	int Status;
+
+	Status = can_init();
+	if (Status != SUCCESS) {
+		return FAILURE;
+	}
+	return SUCCESS;
+}
+
+int task_can_setmode(uint32_t mode)
+{
+	int Status;
+
+	Status = can_setmode(mode);
+	if (Status != SUCCESS) {
+		return FAILURE;
+	}
+	return SUCCESS;
+}
+
+int task_can_setbaud(int baud)
+{
+	int Status;
+	Status = can_setbaud(baud);
+	if (Status != SUCCESS) {
+		return FAILURE;
+	}
+	return SUCCESS;
+}
+
+int task_can_set_btr(int jump, int first_time, int second_time)
+{
+	int Status;
+	Status = can_set_btr(jump, first_time, second_time);
+	if (Status != SUCCESS) {
+		return FAILURE;
+	}
+	return SUCCESS;
+}
+
+void task_can_callback(void *arg)
+{
+#if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_D
+
+#endif // USER_CONFIG_HARDWARE_TARGET
+}
+
+#endif // APP_CAN

--- a/sdk/bare/common/usr/can/task_can.c
+++ b/sdk/bare/common/usr/can/task_can.c
@@ -14,6 +14,10 @@ static task_control_block_t tcb;
 
 int task_can_init(void)
 {
+
+	// Initialize the can peripheral
+	can_init();
+
     if (scheduler_tcb_is_registered(&tcb)) {
         return FAILURE;
     }
@@ -40,11 +44,21 @@ int task_can_loopback_test(void) {
 	return SUCCESS;
 }
 
-int task_can_sendframe()
+int task_can_sendmessage(uint8_t* packet, int num_bytes)
 {
 	int Status;
 
-	Status = can_init();
+	Status = can_send(packet, num_bytes);
+	if (Status != SUCCESS) {
+		return FAILURE;
+	}
+	return SUCCESS;
+}
+
+int task_can_print()
+{
+	int Status;
+	Status = can_print();
 	if (Status != SUCCESS) {
 		return FAILURE;
 	}

--- a/sdk/bare/common/usr/can/task_can.c
+++ b/sdk/bare/common/usr/can/task_can.c
@@ -71,6 +71,12 @@ int task_can_print_mode()
 	return SUCCESS;
 }
 
+int task_can_print_peripheral()
+{
+	can_print_peripheral();
+	return SUCCESS;
+}
+
 int task_can_setmode(uint32_t mode)
 {
 	int Status;
@@ -99,6 +105,15 @@ int task_can_set_btr(int jump, int first_time, int second_time)
 	if (Status != SUCCESS) {
 		return FAILURE;
 	}
+	return SUCCESS;
+}
+
+int task_can_set_peripheral(int device_id)
+{
+	int Status;
+	Status = can_set_peripheral(device_id);
+	if (Status != SUCCESS)
+		return FAILURE;
 	return SUCCESS;
 }
 

--- a/sdk/bare/common/usr/can/task_can.c
+++ b/sdk/bare/common/usr/can/task_can.c
@@ -16,7 +16,7 @@ int task_can_init(void)
 {
 
 	// Initialize the can peripheral
-	can_init();
+	//	can_init(0);
 
     if (scheduler_tcb_is_registered(&tcb)) {
         return FAILURE;
@@ -62,6 +62,12 @@ int task_can_print()
 	if (Status != SUCCESS) {
 		return FAILURE;
 	}
+	return SUCCESS;
+}
+
+int task_can_print_mode()
+{
+	can_print_mode();
 	return SUCCESS;
 }
 

--- a/sdk/bare/common/usr/can/task_can.c
+++ b/sdk/bare/common/usr/can/task_can.c
@@ -15,8 +15,8 @@ static task_control_block_t tcb;
 int task_can_init(void)
 {
 
-	// Initialize the can peripheral
-	//	can_init(0);
+    // Initialize the can peripheral
+    //	can_init(0);
 
     if (scheduler_tcb_is_registered(&tcb)) {
         return FAILURE;
@@ -35,86 +35,87 @@ int task_can_deinit(void)
     return scheduler_tcb_unregister(&tcb);
 }
 
-int task_can_loopback_test(void) {
-	int Status;
-	Status = can_loopback_test();
-	if (Status != SUCCESS) {
-		return FAILURE;
-	}
-	return SUCCESS;
+int task_can_loopback_test(void)
+{
+    int Status;
+    Status = can_loopback_test();
+    if (Status != SUCCESS) {
+        return FAILURE;
+    }
+    return SUCCESS;
 }
 
-int task_can_sendmessage(uint8_t* packet, int num_bytes)
+int task_can_sendmessage(uint8_t *packet, int num_bytes)
 {
-	int Status;
+    int Status;
 
-	Status = can_send(packet, num_bytes);
-	if (Status != SUCCESS) {
-		return FAILURE;
-	}
-	return SUCCESS;
+    Status = can_send(packet, num_bytes);
+    if (Status != SUCCESS) {
+        return FAILURE;
+    }
+    return SUCCESS;
 }
 
 int task_can_print()
 {
-	int Status;
-	Status = can_print();
-	if (Status != SUCCESS) {
-		return FAILURE;
-	}
-	return SUCCESS;
+    int Status;
+    Status = can_print();
+    if (Status != SUCCESS) {
+        return FAILURE;
+    }
+    return SUCCESS;
 }
 
 int task_can_print_mode()
 {
-	can_print_mode();
-	return SUCCESS;
+    can_print_mode();
+    return SUCCESS;
 }
 
 int task_can_print_peripheral()
 {
-	can_print_peripheral();
-	return SUCCESS;
+    can_print_peripheral();
+    return SUCCESS;
 }
 
 int task_can_setmode(uint32_t mode)
 {
-	int Status;
+    int Status;
 
-	Status = can_setmode(mode);
-	if (Status != SUCCESS) {
-		return FAILURE;
-	}
-	return SUCCESS;
+    Status = can_setmode(mode);
+    if (Status != SUCCESS) {
+        return FAILURE;
+    }
+    return SUCCESS;
 }
 
 int task_can_setbaud(int baud)
 {
-	int Status;
-	Status = can_setbaud(baud);
-	if (Status != SUCCESS) {
-		return FAILURE;
-	}
-	return SUCCESS;
+    int Status;
+    Status = can_setbaud(baud);
+    if (Status != SUCCESS) {
+        return FAILURE;
+    }
+    return SUCCESS;
 }
 
 int task_can_set_btr(int jump, int first_time, int second_time)
 {
-	int Status;
-	Status = can_set_btr(jump, first_time, second_time);
-	if (Status != SUCCESS) {
-		return FAILURE;
-	}
-	return SUCCESS;
+    int Status;
+    Status = can_set_btr(jump, first_time, second_time);
+    if (Status != SUCCESS) {
+        return FAILURE;
+    }
+    return SUCCESS;
 }
 
 int task_can_set_peripheral(int device_id)
 {
-	int Status;
-	Status = can_set_peripheral(device_id);
-	if (Status != SUCCESS)
-		return FAILURE;
-	return SUCCESS;
+    int Status;
+    Status = can_set_peripheral(device_id);
+    if (Status != SUCCESS)
+        return FAILURE;
+    return SUCCESS;
 }
 
 void task_can_callback(void *arg)

--- a/sdk/bare/common/usr/can/task_can.h
+++ b/sdk/bare/common/usr/can/task_can.h
@@ -1,0 +1,36 @@
+#ifndef TASK_CAN_H
+#define TASK_CAN_H
+
+#include "sys/scheduler.h"
+
+// Frequency that this task is called (in Hz)
+//
+// Must be less than or equal to scheduler updates per second
+// This value is defined in sys/scheduler.h and defaults to 10kHz.
+// Note that it can be overridden via usr/user_config.h
+#define TASK_CAN_UPDATES_PER_SEC (10000)
+
+// Microseconds interval between when task is called
+//
+// This is what scheduler actually uses to run task,
+// but is generated via define above
+#define TASK_CAN_INTERVAL_USEC (USEC_IN_SEC / TASK_CAN_UPDATES_PER_SEC)
+
+int task_can_init(void);
+
+int task_can_deinit(void);
+
+int task_can_loopback_test(void);
+
+int task_can_sendframe();
+
+int task_can_setmode(uint32_t);
+
+int task_can_setbaud(int);
+
+int task_can_set_btr(int, int, int);
+
+// Callback function which scheduler calls periodically
+void task_can_callback(void *arg);
+
+#endif // TASK_CAN_H

--- a/sdk/bare/common/usr/can/task_can.h
+++ b/sdk/bare/common/usr/can/task_can.h
@@ -28,11 +28,16 @@ int task_can_print();
 
 int task_can_print_mode();
 
+int task_can_print_peripheral();
+
 int task_can_setmode(uint32_t);
 
 int task_can_setbaud(int);
 
 int task_can_set_btr(int, int, int);
+
+int task_can_set_peripheral(int);
+
 
 // Callback function which scheduler calls periodically
 void task_can_callback(void *arg);

--- a/sdk/bare/common/usr/can/task_can.h
+++ b/sdk/bare/common/usr/can/task_can.h
@@ -26,6 +26,8 @@ int task_can_sendmessage(uint8_t*, int);
 
 int task_can_print();
 
+int task_can_print_mode();
+
 int task_can_setmode(uint32_t);
 
 int task_can_setbaud(int);

--- a/sdk/bare/common/usr/can/task_can.h
+++ b/sdk/bare/common/usr/can/task_can.h
@@ -22,7 +22,9 @@ int task_can_deinit(void);
 
 int task_can_loopback_test(void);
 
-int task_can_sendframe();
+int task_can_sendmessage(uint8_t*, int);
+
+int task_can_print();
 
 int task_can_setmode(uint32_t);
 

--- a/sdk/bare/common/usr/can/task_can.h
+++ b/sdk/bare/common/usr/can/task_can.h
@@ -22,7 +22,7 @@ int task_can_deinit(void);
 
 int task_can_loopback_test(void);
 
-int task_can_sendmessage(uint8_t*, int);
+int task_can_sendmessage(uint8_t *, int);
 
 int task_can_print();
 
@@ -37,7 +37,6 @@ int task_can_setbaud(int);
 int task_can_set_btr(int, int, int);
 
 int task_can_set_peripheral(int);
-
 
 // Callback function which scheduler calls periodically
 void task_can_callback(void *arg);

--- a/sdk/bare/user/.cproject
+++ b/sdk/bare/user/.cproject
@@ -14,15 +14,15 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactExtension="elf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" cleanCommand="rm -rf" description="" id="xilinx.gnu.armv7.exe.debug.994846576" name="Debug" parent="xilinx.gnu.armv7.exe.debug" prebuildStep="a9-linaro-pre-build-step">
+				<configuration artifactExtension="elf" artifactName="${ProjName}" buildArtefactType="org.eclipse.cdt.build.core.buildArtefactType.exe" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=org.eclipse.cdt.build.core.buildArtefactType.exe,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" cleanCommand="rm -rf" description="" errorParsers="org.eclipse.cdt.core.GASErrorParser;org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.GLDErrorParser;org.eclipse.cdt.core.CWDLocator;org.eclipse.cdt.core.GCCErrorParser" id="xilinx.gnu.armv7.exe.debug.994846576" name="Debug" parent="xilinx.gnu.armv7.exe.debug" postannouncebuildStep="" postbuildStep="" preannouncebuildStep="" prebuildStep="a9-linaro-pre-build-step">
 					<folderInfo id="xilinx.gnu.armv7.exe.debug.994846576." name="/" resourcePath="">
-						<toolChain id="xilinx.gnu.armv7.exe.debug.toolchain.675664127" name="Xilinx ARM v7 GNU Toolchain" superClass="xilinx.gnu.armv7.exe.debug.toolchain">
+						<toolChain errorParsers="" id="xilinx.gnu.armv7.exe.debug.toolchain.675664127" name="Xilinx ARM v7 GNU Toolchain" superClass="xilinx.gnu.armv7.exe.debug.toolchain">
 							<targetPlatform binaryParser="com.xilinx.sdk.managedbuilder.XELF.arm.a53.x32" id="xilinx.armv7.target.gnu.base.debug.722028308" isAbstract="false" name="Debug Platform" superClass="xilinx.armv7.target.gnu.base.debug"/>
-							<builder buildPath="${workspace_loc:/bare}/Debug" enableAutoBuild="true" id="xilinx.gnu.armv7.toolchain.builder.debug.873230648" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="GNU make" superClass="xilinx.gnu.armv7.toolchain.builder.debug"/>
-							<tool id="xilinx.gnu.armv7.c.toolchain.assembler.debug.1801385722" name="ARM v7 gcc assembler" superClass="xilinx.gnu.armv7.c.toolchain.assembler.debug">
+							<builder buildPath="${workspace_loc:/bare}/Debug" enableAutoBuild="true" errorParsers="org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.CWDLocator" id="xilinx.gnu.armv7.toolchain.builder.debug.873230648" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="GNU make" superClass="xilinx.gnu.armv7.toolchain.builder.debug"/>
+							<tool command="arm-none-eabi-gcc" commandLinePattern="${COMMAND} -c ${FLAGS} ${OUTPUT_FLAG}${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GASErrorParser" id="xilinx.gnu.armv7.c.toolchain.assembler.debug.1801385722" name="ARM v7 gcc assembler" superClass="xilinx.gnu.armv7.c.toolchain.assembler.debug">
 								<inputType id="xilinx.gnu.assembler.input.631082709" superClass="xilinx.gnu.assembler.input"/>
 							</tool>
-							<tool id="xilinx.gnu.armv7.c.toolchain.compiler.debug.172815694" name="ARM v7 gcc compiler" superClass="xilinx.gnu.armv7.c.toolchain.compiler.debug">
+							<tool command="arm-none-eabi-gcc" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GCCErrorParser" id="xilinx.gnu.armv7.c.toolchain.compiler.debug.172815694" name="ARM v7 gcc compiler" superClass="xilinx.gnu.armv7.c.toolchain.compiler.debug">
 								<option defaultValue="gnu.c.optimization.level.none" id="xilinx.gnu.compiler.option.optimization.level.1946302083" name="Optimization Level" superClass="xilinx.gnu.compiler.option.optimization.level" valueType="enumerated"/>
 								<option id="xilinx.gnu.compiler.option.debugging.level.1813210300" name="Debug Level" superClass="xilinx.gnu.compiler.option.debugging.level" value="gnu.c.debugging.level.max" valueType="enumerated"/>
 								<option id="xilinx.gnu.compiler.inferred.swplatform.includes.1012021837" name="Software Platform Include Path" superClass="xilinx.gnu.compiler.inferred.swplatform.includes"/>
@@ -31,6 +31,7 @@
 								<option id="xilinx.gnu.compiler.symbols.defined.1897050119" name="Defined symbols (-D)" superClass="xilinx.gnu.compiler.symbols.defined" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="APP_BLINK"/>
 									<listOptionValue builtIn="false" value="APP_PCBTEST"/>
+									<listOptionValue builtIn="false" value="APP_CAN"/>
 								</option>
 								<option id="xilinx.gnu.compiler.dircategory.includes.1596529872" name="Include Paths" superClass="xilinx.gnu.compiler.dircategory.includes" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/amdc_bsp/ps7_cortexa9_0/include}&quot;"/>
@@ -48,7 +49,7 @@
 								<option id="xilinx.gnu.compiler.inferred.swplatform.flags.289628954" name="Software Platform Inferred Flags" superClass="xilinx.gnu.compiler.inferred.swplatform.flags" value="  " valueType="string"/>
 							</tool>
 							<tool id="xilinx.gnu.armv7.toolchain.archiver.357721109" name="ARM v7 archiver" superClass="xilinx.gnu.armv7.toolchain.archiver"/>
-							<tool id="xilinx.gnu.armv7.c.toolchain.linker.debug.387215090" name="ARM v7 gcc linker" superClass="xilinx.gnu.armv7.c.toolchain.linker.debug">
+							<tool command="arm-none-eabi-gcc" commandLinePattern="${COMMAND} ${FLAGS} ${OUTPUT_FLAG} ${OUTPUT_PREFIX}${OUTPUT} ${INPUTS}" errorParsers="org.eclipse.cdt.core.GLDErrorParser" id="xilinx.gnu.armv7.c.toolchain.linker.debug.387215090" name="ARM v7 gcc linker" superClass="xilinx.gnu.armv7.c.toolchain.linker.debug">
 								<option id="xilinx.gnu.linker.inferred.swplatform.lpath.1777577282" name="Software Platform Library Path" superClass="xilinx.gnu.linker.inferred.swplatform.lpath"/>
 								<option id="xilinx.gnu.linker.inferred.swplatform.flags.1492846061" name="Software Platform Inferred Flags" superClass="xilinx.gnu.linker.inferred.swplatform.flags" valueType="libs">
 									<listOptionValue builtIn="false" value="-Wl,--start-group,-lxil,-lgcc,-lc,--end-group"/>
@@ -83,7 +84,7 @@
 								</option>
 								<option id="xilinx.gnu.c.linker.option.lscript.1894835848" name="Linker Script" superClass="xilinx.gnu.c.linker.option.lscript" value="../src/lscript.ld" valueType="string"/>
 							</tool>
-							<tool id="xilinx.gnu.armv7.size.debug.1079631618" name="ARM v7 Print Size" superClass="xilinx.gnu.armv7.size.debug"/>
+							<tool command="arm-none-eabi-size" commandLinePattern="${COMMAND} ${FLAGS} ${INPUTS} |tee ${OUTPUT}" errorParsers="" id="xilinx.gnu.armv7.size.debug.1079631618" name="ARM v7 Print Size" superClass="xilinx.gnu.armv7.size.debug"/>
 						</toolChain>
 					</folderInfo>
 					<sourceEntries>

--- a/sdk/bare/user/usr/user_apps.c
+++ b/sdk/bare/user/usr/user_apps.c
@@ -43,7 +43,7 @@ void user_apps_init(void)
 #endif
 
 #ifdef APP_CAN
-	app_can_init();
+    app_can_init();
 #endif
 
 #ifdef APP_BETA_LABS

--- a/sdk/bare/user/usr/user_apps.c
+++ b/sdk/bare/user/usr/user_apps.c
@@ -16,6 +16,10 @@
 #include "usr/blink/app_blink.h"
 #endif
 
+#ifdef APP_CAN
+#include "usr/can/app_can.h"
+#endif
+
 #ifdef APP_BETA_LABS
 #include "usr/beta_labs/app_beta_labs.h"
 #endif
@@ -36,6 +40,10 @@ void user_apps_init(void)
 
 #ifdef APP_BLINK
     app_blink_init();
+#endif
+
+#ifdef APP_CAN
+	app_can_init();
 #endif
 
 #ifdef APP_BETA_LABS

--- a/sdk/bare/user/usr/user_config.h
+++ b/sdk/bare/user/usr/user_config.h
@@ -7,7 +7,7 @@
 // various system-level firmware features.
 
 // Specify hardware revision (i.e. REV C, REV D, etc)
-#define USER_CONFIG_HARDWARE_TARGET (AMDC_REV_C)
+#define USER_CONFIG_HARDWARE_TARGET (AMDC_REV_D)
 
 // Override the default scheduler elementary frequency by defining SYS_TICK_FREQ here.
 // System uses 10kHz by default
@@ -15,7 +15,7 @@
 
 // Enforce time quantum limits
 // set to 1 for enabled, 0 for disabled
-#define USER_CONFIG_ENABLE_TIME_QUANTUM_CHECKING (1)
+#define USER_CONFIG_ENABLE_TIME_QUANTUM_CHECKING (0)
 
 // Enable task statistic collection by default
 // NOTE: The user can still go and enable the stats themselves if this is set to 0!


### PR DESCRIPTION
This PR is to merge the CAN REV-A board's IP and firmware into develop. This PR contains the necessary IP block and user application firmware to drive the [CAN expansion board](https://github.com/Severson-Group/AMDC-Hardware/tree/develop/Accessories/ExpansionBoard_CAN). Specifically, it contains:
- Wrapper functions around the low-level register manipulation drivers to abstract the low-level details away and provide a clean/easy to use API for the user. The wrapper functions can be found at `sdk/bare/common/drv/can.h`.
- A user app to interact with the CAN peripheral from the command line. The sole purpose of this app is to provide an example of HOW to use the wrapper functions. In reality, users will make calls to the wrapper functions. The code for this user app can be found at ` sdk/bare/common/usr/can/cmd/cmd_can.c` and `sdk/bare/common/usr/can/task_can.c`. 

Originally, a Xilinx provided CAN IP block was going to be used. Due to licensing issues, a bitstream couldn't be generated with this IP block. Thus, given that there are two CAN peripherals baked into the silicon of the Zync-7000 SoC, these peripherals are used and routed to the GPIO expansion ports via EMIO.

Documentation about the CAN drivers can be found [here](https://github.com/Severson-Group/AMDC-Firmware/blob/can-firmware/sdk/bare/common/drv/docs/CAN-Expansion-Board.md).