### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,33 @@
 # Advanced Motor Drive Controller (AMDC) Firmware
 
-The Advanced Motor Drive Controller (AMDC) is an open-source project from the [Severson Research Group](https://severson.wempec.wisc.edu/) at [UW-Madison](http://www.engr.wisc.edu/department/electrical-computer-engineering/), affiliated with [Wisconsin Electric Machines and Power Electronics Consortium (WEMPEC)](https://wempec.wisc.edu/).
+![CI badge](https://github.com/Severson-Group/AMDC-Firmware/actions/workflows/main.yml/badge.svg)
 
-AMDC is a next generation open-source hardware and software control platform for power electronics and motor drives, designed and developed for academic applications. AMDC contains high performance dual-core digital signal processors, tightly integrated custom digital logic (FPGA), and a plethora of extremely flexible inputs and outputs (I/O) designed to interface to motor drives. Low-level firmware drivers have been developed to abstract away the complexities of the software / hardware interface, letting users focus on implementing custom control algorithms. Common use-case controller code is provided which gets new users up and running efficiently. AMDC empowers engineers to control advanced systems with ease.
+*The Advanced Motor Drive Controller (AMDC) is an open-source project from the [Severson Research Group](https://severson.wempec.wisc.edu/) at [UW-Madison](http://www.engr.wisc.edu/department/electrical-computer-engineering/), affiliated with [Wisconsin Electric Machines and Power Electronics Consortium (WEMPEC)](https://wempec.wisc.edu/).*
+
+---
+
+**AMDC-Firmware** is a collection of embedded system code (written in C and Verilog) which runs on the [AMDC Hardware](https://github.com/Severson-Group/AMDC-Hardware) and controls advanced motor systems. It is open-source, high-performance, flexible, and research-oriented.
+
+The target processor is the [Xilinx Zynq-7000 SoC](https://www.xilinx.com/products/silicon-devices/soc/zynq-7000.html) which includes both a dual-core DSP and tightly integrated FPGA. The AMDC firmware utilizes both parts of the processor (DSP + FPGA).
 
 ## Getting Started
 
-The best way to get started with the AMDC platform is by thoroughly reading the documentation &mdash; see the next section.
+1. Obtain a working hardware platform -- see the [AMDC Hardware](https://github.com/Severson-Group/AMDC-Hardware) repo for more information.
+2. Follow the steps outlined [here](https://github.com/Severson-Group/AMDC-Firmware/blob/develop/docs/Building-and-Running-Firmware.md) to download, build, and run the firmware.
+3. Read the [documentation](https://github.com/Severson-Group/AMDC-Firmware/tree/develop/docs) for more insight into the platform.
 
 ## Documentation
 
-Detailed documentation about the AMDC firmware is available in the `docs/` subfolder of this repo. [Check it out...](docs/)
+Detailed documentation about the AMDC firmware is available in the [`docs/` subfolder](docs/) of this repo.
 
 ## License
 
 This project is licensed under the BSD-3-Clause License - see the [LICENSE.md](LICENSE.md) file for details.
+
+## Contribute
+
+Want to help build the open-source motor drive platform of choice? Join the people below -- **[Contribute today!](./CONTRIBUTING.md)**
+
+<a href="https://github.com/Severson-Group/AMDC-Hardware/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Severson-Group/AMDC-Hardware" />
+</a>


### PR DESCRIPTION
When people come to this repo, they should read the README file and get a flavor of what is implemented in the code base -- the processor system, firmware, etc.

I tried to update the README to be more like open-source projects, instead of ad for the AMDC. The ad for the AMDC should go on www.amdc.dev.