### PR TITLE
Fixed bug in sensor firmware

### DIFF
--- a/sdk/bare/common/drv/eddy_current_sensor.c
+++ b/sdk/bare/common/drv/eddy_current_sensor.c
@@ -17,7 +17,6 @@ void eddy_current_sensor_init(void)
 
     // Set sampling rate to 20kHz
     eddy_current_sensor_set_sample_rate(20000);
-    eddy_current_sensor_enable();
 }
 
 void eddy_current_sensor_enable(void)
@@ -42,7 +41,7 @@ void eddy_current_sensor_set_divider(uint8_t divider)
     Xil_Out32(EDDY_CURRENT_SENSOR_BASE_ADDR + (2 * sizeof(uint32_t)), divider);
 }
 
-double eddy_current_sensor_bits_to_voltage(uint32_t data)
+static double bits_to_voltage(uint32_t data)
 {
     bool is_negative = 0x20000 & data;
 
@@ -57,7 +56,7 @@ double eddy_current_sensor_bits_to_voltage(uint32_t data)
     double voltage = (0x1FFFF & data) * resolution; // 17-bit data
 
     if (is_negative) {
-        return -voltage;
+        voltage = -voltage;
     }
 
     return voltage;

--- a/sdk/bare/common/drv/eddy_current_sensor.c
+++ b/sdk/bare/common/drv/eddy_current_sensor.c
@@ -66,14 +66,14 @@ double eddy_current_sensor_read_x_voltage(void)
 {
     uint32_t x_data = Xil_In32(EDDY_CURRENT_SENSOR_BASE_ADDR);
 
-    return eddy_current_sensor_bits_to_voltage(x_data);
+    return bits_to_voltage(x_data);
 }
 
 double eddy_current_sensor_read_y_voltage(void)
 {
     uint32_t y_data = Xil_In32(EDDY_CURRENT_SENSOR_BASE_ADDR + (1 * sizeof(uint32_t)));
 
-    return eddy_current_sensor_bits_to_voltage(y_data);
+    return bits_to_voltage(y_data);
 }
 
 #endif // USER_CONFIG_HARDWARE_TARGET

--- a/sdk/bare/common/drv/eddy_current_sensor.c
+++ b/sdk/bare/common/drv/eddy_current_sensor.c
@@ -32,7 +32,7 @@ void eddy_current_sensor_disable(void)
 
 void eddy_current_sensor_set_sample_rate(double sample_rate)
 {
-    uint8_t divider = (uint8_t) (500000 / sample_rate);
+    uint8_t divider = (uint8_t)(500000 / sample_rate);
 
     eddy_current_sensor_set_divider(divider - 1);
 }

--- a/sdk/bare/common/drv/eddy_current_sensor.c
+++ b/sdk/bare/common/drv/eddy_current_sensor.c
@@ -32,7 +32,7 @@ void eddy_current_sensor_disable(void)
 
 void eddy_current_sensor_set_sample_rate(double sample_rate)
 {
-    uint8_t divider = (uint8_t)(500000 / sample_rate);
+    uint8_t divider = (uint8_t) (500000 / sample_rate);
 
     eddy_current_sensor_set_divider(divider - 1);
 }
@@ -48,16 +48,17 @@ double eddy_current_sensor_bits_to_voltage(uint32_t data)
 
     // Convert 2's compliment to positive data
     if (is_negative) {
-    	data = ~data;
-    	data += 1;
+        data = ~data;
+        data += 1;
     }
 
     // Convert data to voltage (+/-5V)
-    double resolution = 0.00003814697; 					// 5V / 2^17
-    double voltage = (0x1FFFF & data) * resolution;		// 17-bit data
+    double resolution = 0.00003814697;              // 5V / 2^17
+    double voltage = (0x1FFFF & data) * resolution; // 17-bit data
 
-    if (is_negative)
-    	return -voltage;
+    if (is_negative) {
+        return -voltage;
+    }
 
     return voltage;
 }

--- a/sdk/bare/common/drv/eddy_current_sensor.c
+++ b/sdk/bare/common/drv/eddy_current_sensor.c
@@ -5,9 +5,9 @@
 
 #include "drv/eddy_current_sensor.h"
 #include "xil_io.h"
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <stdbool.h>
 
 #define EDDY_CURRENT_SENSOR_BASE_ADDR (0x43C80000)
 
@@ -52,7 +52,7 @@ double eddy_current_sensor_bits_to_voltage(uint32_t data)
     	data += 1;
     }
 
-    // Convert data to voltage +-5V
+    // Convert data to voltage (+/-5V)
     double resolution = 0.00003814697; 					// 5V / 2^17
     double voltage = (0x1FFFF & data) * resolution;		// 17-bit data
 


### PR DESCRIPTION
This PR is to merge the eddy_current_sensor branch into develop. The data coming from the sensor was in 2's compliment which was not being handle correctly in the C drivers. The driver now correctly assumes the data from the FPGA to be in 2's compliment and handles the data appropriately.