### PR TITLE
Fix injection command handling for const

### DIFF
--- a/sdk/bare/common/sys/cmd/cmd_inj.c
+++ b/sdk/bare/common/sys/cmd/cmd_inj.c
@@ -73,10 +73,7 @@ int cmd_inj(int argc, char **argv)
             return CMD_INVALID_ARGUMENTS;
 
         // Pull out value argument
-        // and saturate to -10 .. 10
-        double value = strtod(argv[5], NULL);
-        if (value < -10.0 || value > 10.0)
-            return CMD_INVALID_ARGUMENTS;
+        double value = strtod(argv[4], NULL);
 
         injection_const(ctx, op, value);
 


### PR DESCRIPTION
Found a long-living minor bug in the injection engine command processing. This explains why the `const` command never worked for me! :)

Key fix was changing the `argv` indexing to the correct location.