### PR TITLE
Update IP address in C code to match Vivado

### DIFF
--- a/sdk/bare/common/drv/motherboard.h
+++ b/sdk/bare/common/drv/motherboard.h
@@ -13,7 +13,7 @@
 #endif
 
 #if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_D
-#define MOTHERBOARD_BASE_ADDR (0x43C70000)
+#define MOTHERBOARD_BASE_ADDR (0x43C90000)
 #endif
 
 typedef enum {


### PR DESCRIPTION
In the shuffle, the C address mapping to the IP block got mixed up. This PR fixes it.

See this line in the block diagram for proof the new address is correct:
https://github.com/Severson-Group/AMDC-Firmware/blob/develop/hw/amdc_revd.bd#L5135