### PR TITLE
Increase command arg length limit

### DIFF
--- a/sdk/bare/common/sys/commands.c
+++ b/sdk/bare/common/sys/commands.c
@@ -17,7 +17,7 @@ static char recv_buffer[RECV_BUFFER_LENGTH] = { 0 };
 static int recv_buffer_idx = 0;
 
 #define CMD_MAX_ARGC       (16) // # of args accepted
-#define CMD_MAX_ARG_LENGTH (24) // max chars of any arg
+#define CMD_MAX_ARG_LENGTH (32) // max chars of any arg
 typedef struct pending_cmd_t {
     int argc;
     char *argv[CMD_MAX_ARGC];


### PR DESCRIPTION
To prevent issues, this PR increases the command arg length limit. I needed to do this because of trying to register rather long variables names for logging due to autogen simulink outputs.

However, I think this is a safe change. This limit is placed due to timing determinism in parsing the command input, but it should still be fast enough with slightly longer arg length.