### PR TITLE
Add support for clearing all logged variables in firmware

### DIFF
--- a/scripts/AMDC_Logger.py
+++ b/scripts/AMDC_Logger.py
@@ -130,8 +130,9 @@ class AMDC_Logger():
         
     def clear_all(self):
         
-        for var in self.log_vars:
-            self.clear(var)
+        self.amdc.cmd(f'log empty_all')
+        #for var in self.log_vars:
+        #    self.clear(var)
         
     def auto_find_vars(self, root):
         

--- a/sdk/bare/common/sys/cmd/cmd_log.c
+++ b/sdk/bare/common/sys/cmd/cmd_log.c
@@ -20,6 +20,7 @@ static command_help_t cmd_help[] = {
     { "stop", "Stop logging" },
     { "dump <bin|text> <log_var_idx>", "Dump log data to console" },
     { "empty <log_var_idx>", "Empty log for a previously logged variable (stays registered)" },
+	{ "empty_all", "Empty all slots" },
     { "info", "Print status of logging engine" },
 };
 
@@ -186,6 +187,16 @@ int cmd_log(int argc, char **argv)
         }
 
         int err = log_var_empty(log_var_idx);
+        if (err != SUCCESS) {
+            return CMD_FAILURE;
+        }
+
+        return CMD_SUCCESS;
+    }
+
+    // Handle 'empty_all' sub-command
+    if (argc == 2 && strcmp("empty_all", argv[1]) == 0) {
+        int err = log_var_empty_all();
         if (err != SUCCESS) {
             return CMD_FAILURE;
         }

--- a/sdk/bare/common/sys/cmd/cmd_log.c
+++ b/sdk/bare/common/sys/cmd/cmd_log.c
@@ -20,7 +20,7 @@ static command_help_t cmd_help[] = {
     { "stop", "Stop logging" },
     { "dump <bin|text> <log_var_idx>", "Dump log data to console" },
     { "empty <log_var_idx>", "Empty log for a previously logged variable (stays registered)" },
-	{ "empty_all", "Empty all slots" },
+    { "empty_all", "Empty all slots" },
     { "info", "Print status of logging engine" },
 };
 

--- a/sdk/bare/common/sys/log.c
+++ b/sdk/bare/common/sys/log.c
@@ -221,6 +221,17 @@ int log_var_empty(int idx)
     return SUCCESS;
 }
 
+int log_var_empty_all(void)
+{
+	for (int idx = 0; idx < LOG_MAX_NUM_VARIABLES; idx++) {
+	    vars[idx].buffer_idx = 0;
+	    vars[idx].last_logged_usec = 0;
+	    vars[idx].num_samples = 0;
+	}
+
+	return SUCCESS;
+}
+
 // ***************************
 // Code for running the state machine to
 // dump the log buffers to the UART

--- a/sdk/bare/common/sys/log.c
+++ b/sdk/bare/common/sys/log.c
@@ -223,13 +223,13 @@ int log_var_empty(int idx)
 
 int log_var_empty_all(void)
 {
-	for (int idx = 0; idx < LOG_MAX_NUM_VARIABLES; idx++) {
-	    vars[idx].buffer_idx = 0;
-	    vars[idx].last_logged_usec = 0;
-	    vars[idx].num_samples = 0;
-	}
+    for (int idx = 0; idx < LOG_MAX_NUM_VARIABLES; idx++) {
+        vars[idx].buffer_idx = 0;
+        vars[idx].last_logged_usec = 0;
+        vars[idx].num_samples = 0;
+    }
 
-	return SUCCESS;
+    return SUCCESS;
 }
 
 // ***************************

--- a/sdk/bare/common/sys/log.h
+++ b/sdk/bare/common/sys/log.h
@@ -63,6 +63,8 @@ bool log_is_logging(void);
 int log_var_register(int idx, char *name, void *addr, uint32_t samples_per_sec, var_type_e type);
 
 int log_var_empty(int idx);
+int log_var_empty_all(void);
+
 int log_var_dump_uart_ascii(int idx);
 int log_var_dump_uart_binary(int idx);
 


### PR DESCRIPTION
Closes #143 

Anyone who has used the logging framework with 10s of variables will tell you it takes a while to clear all the log slots.

With this PR, a new command is added to clear all slots in one go. This dramatically speeds up scripting and experiments.