### PR TITLE
Update scheduler to use consistent time throughout time slice

### DIFF
--- a/sdk/bare/common/sys/scheduler.c
+++ b/sdk/bare/common/sys/scheduler.c
@@ -167,7 +167,7 @@ void scheduler_run(void)
 
     // This is the main event loop that runs the device
     while (1) {
-    	uint32_t my_elapsed_usec = elapsed_usec;
+        uint32_t my_elapsed_usec = elapsed_usec;
         tasks_running = true;
 
         task_control_block_t *t = tasks;

--- a/sdk/bare/common/sys/scheduler.c
+++ b/sdk/bare/common/sys/scheduler.c
@@ -20,7 +20,7 @@ static task_control_block_t *tasks = NULL;
 static task_control_block_t *running_task = NULL;
 
 // Incremented every SysTick interrupt to track time
-static uint32_t elapsed_usec = 0;
+static volatile uint32_t elapsed_usec = 0;
 
 static bool tasks_running = false;
 static volatile bool scheduler_idle = false;
@@ -167,11 +167,12 @@ void scheduler_run(void)
 
     // This is the main event loop that runs the device
     while (1) {
+    	uint32_t my_elapsed_usec = elapsed_usec;
         tasks_running = true;
 
         task_control_block_t *t = tasks;
         while (t != NULL) {
-            uint32_t usec_since_last_run = elapsed_usec - t->last_run_usec;
+            uint32_t usec_since_last_run = my_elapsed_usec - t->last_run_usec;
 
             if (usec_since_last_run >= t->interval_usec) {
                 // Time to run this task!
@@ -181,7 +182,7 @@ void scheduler_run(void)
                 running_task = NULL;
                 task_stats_post_task(&t->stats);
 
-                t->last_run_usec = elapsed_usec;
+                t->last_run_usec = my_elapsed_usec;
             }
 
             // Go to next task in linked list


### PR DESCRIPTION
This PR slightly changes the scheduler to acknowledge that the `elapsed_usec` variable is volatile and could possibly change during the time slice, *only if a task overruns*.

This was happening to me, so I wanted to make sure it wouldn't accidently get rescheduled for the current time slice.

This PR should have no functional changes for the nominal case of all tasks finishing within the time slice.