### PR TITLE
Add square wave injection signal capability

### DIFF
--- a/sdk/bare/common/sys/cmd/cmd_inj.c
+++ b/sdk/bare/common/sys/cmd/cmd_inj.c
@@ -33,10 +33,10 @@ void cmd_inj_register(void)
 
 static int _parse_op(char *op_str, inj_op_e *inj_op)
 {
-	// Default to error state:
-	// -1 : error
-	//  0 : no error
-	int error = -1;
+    // Default to error state:
+    // -1 : error
+    //  0 : no error
+    int error = -1;
 
     if (STREQ("set", op_str)) {
         *inj_op = SET;
@@ -132,7 +132,7 @@ int cmd_inj(int argc, char **argv)
         double gain = strtod(argv[4], NULL);
         if (gain < 0.0) {
             return CMD_INVALID_ARGUMENTS;
-    	}
+        }
 
         // Pull out freqMin argument
         // and saturate to 0+

--- a/sdk/bare/common/sys/cmd/cmd_inj.c
+++ b/sdk/bare/common/sys/cmd/cmd_inj.c
@@ -19,6 +19,7 @@ static command_help_t cmd_help[] = {
     { "noise <name> <set|add|sub> <gain> <offset>", "Inject noise" },
     { "chirp <name> <set|add|sub> <gain> <freqMin> <freqMax> <period>", "Inject chirp" },
     { "triangle <name> <set|add|sub> <valueMin> <valueMax> <period>", "Inject triangle" },
+    { "square <name> <set|add|sub> <valueMin> <valueMax> <period>", "Inject square" },
 };
 
 void cmd_inj_register(void)
@@ -32,18 +33,23 @@ void cmd_inj_register(void)
 
 static int _parse_op(char *op_str, inj_op_e *inj_op)
 {
+	// Default to error state:
+	// -1 : error
+	//  0 : no error
+	int error = -1;
+
     if (STREQ("set", op_str)) {
         *inj_op = SET;
-        return 0;
+        error = 0;
     } else if (STREQ("add", op_str)) {
         *inj_op = ADD;
-        return 0;
+        error = 0;
     } else if (STREQ("sub", op_str)) {
         *inj_op = SUB;
-        return 0;
+        error = 0;
     }
 
-    return -1;
+    return error;
 }
 
 int cmd_inj(int argc, char **argv)
@@ -64,13 +70,15 @@ int cmd_inj(int argc, char **argv)
     if (argc == 5 && STREQ("const", argv[1])) {
         // Parse out name and convert to injection context
         inj_ctx_t *ctx = injection_find_ctx_by_name(argv[2]);
-        if (ctx == NULL)
+        if (ctx == NULL) {
             return CMD_INVALID_ARGUMENTS;
+        }
 
         // Parse out operation
         inj_op_e op;
-        if (_parse_op(argv[3], &op) != 0)
+        if (_parse_op(argv[3], &op) != 0) {
             return CMD_INVALID_ARGUMENTS;
+        }
 
         // Pull out value argument
         double value = strtod(argv[4], NULL);
@@ -84,13 +92,15 @@ int cmd_inj(int argc, char **argv)
     if (argc == 6 && STREQ("noise", argv[1])) {
         // Parse out name and convert to injection context
         inj_ctx_t *ctx = injection_find_ctx_by_name(argv[2]);
-        if (ctx == NULL)
+        if (ctx == NULL) {
             return CMD_INVALID_ARGUMENTS;
+        }
 
         // Parse out operation
         inj_op_e op;
-        if (_parse_op(argv[3], &op) != 0)
+        if (_parse_op(argv[3], &op) != 0) {
             return CMD_INVALID_ARGUMENTS;
+        }
 
         // Pull out gain argument
         double gain = strtod(argv[4], NULL);
@@ -107,36 +117,42 @@ int cmd_inj(int argc, char **argv)
     if (argc == 8 && STREQ("chirp", argv[1])) {
         // Parse out name and convert to injection context
         inj_ctx_t *ctx = injection_find_ctx_by_name(argv[2]);
-        if (ctx == NULL)
+        if (ctx == NULL) {
             return CMD_INVALID_ARGUMENTS;
+        }
 
         // Parse out operation
         inj_op_e op;
-        if (_parse_op(argv[3], &op) != 0)
+        if (_parse_op(argv[3], &op) != 0) {
             return CMD_INVALID_ARGUMENTS;
+        }
 
         // Pull out gain argument
         // and saturate to 0+
         double gain = strtod(argv[4], NULL);
-        if (gain < 0.0)
+        if (gain < 0.0) {
             return CMD_INVALID_ARGUMENTS;
+    	}
 
         // Pull out freqMin argument
         // and saturate to 0+
         double freqMin = strtod(argv[5], NULL);
-        if (freqMin < 0.0)
+        if (freqMin < 0.0) {
             return CMD_INVALID_ARGUMENTS;
+        }
 
         // Pull out freqMax argument
         // and saturate to 0+
-        double freqMax = strtod(argv[5], NULL);
-        if (freqMax < 0.0)
+        double freqMax = strtod(argv[6], NULL);
+        if (freqMax < 0.0) {
             return CMD_INVALID_ARGUMENTS;
+        }
 
         // Pull out period argument
         double period = strtod(argv[7], NULL);
-        if (period < 0.0)
+        if (period < 0.0) {
             return CMD_INVALID_ARGUMENTS;
+        }
 
         injection_chirp(ctx, op, gain, freqMin, freqMax, period);
 
@@ -147,13 +163,15 @@ int cmd_inj(int argc, char **argv)
     if (argc == 7 && STREQ("triangle", argv[1])) {
         // Parse out name and convert to injection context
         inj_ctx_t *ctx = injection_find_ctx_by_name(argv[2]);
-        if (ctx == NULL)
+        if (ctx == NULL) {
             return CMD_INVALID_ARGUMENTS;
+        }
 
         // Parse out operation
         inj_op_e op;
-        if (_parse_op(argv[3], &op) != 0)
+        if (_parse_op(argv[3], &op) != 0) {
             return CMD_INVALID_ARGUMENTS;
+        }
 
         // Pull out valueMin argument
         double valueMin = strtod(argv[4], NULL);
@@ -163,10 +181,42 @@ int cmd_inj(int argc, char **argv)
 
         // Pull out period argument
         double period = strtod(argv[6], NULL);
-        if (period < 0.0)
+        if (period < 0.0) {
             return CMD_INVALID_ARGUMENTS;
+        }
 
         injection_triangle(ctx, op, valueMin, valueMax, period);
+
+        return CMD_SUCCESS;
+    }
+
+    // Handle 'inj square ...' command
+    if (argc == 7 && STREQ("square", argv[1])) {
+        // Parse out name and convert to injection context
+        inj_ctx_t *ctx = injection_find_ctx_by_name(argv[2]);
+        if (ctx == NULL) {
+            return CMD_INVALID_ARGUMENTS;
+        }
+
+        // Parse out operation
+        inj_op_e op;
+        if (_parse_op(argv[3], &op) != 0) {
+            return CMD_INVALID_ARGUMENTS;
+        }
+
+        // Pull out valueMin argument
+        double valueMin = strtod(argv[4], NULL);
+
+        // Pull out valueMax argument
+        double valueMax = strtod(argv[5], NULL);
+
+        // Pull out period argument
+        double period = strtod(argv[6], NULL);
+        if (period < 0.0) {
+            return CMD_INVALID_ARGUMENTS;
+        }
+
+        injection_square(ctx, op, valueMin, valueMax, period);
 
         return CMD_SUCCESS;
     }

--- a/sdk/bare/common/sys/injection.c
+++ b/sdk/bare/common/sys/injection.c
@@ -84,13 +84,13 @@ static inline double _triangle(double min, double max, double period, double tim
 
 static inline double _square(double min, double max, double period, double time)
 {
-	// Output defaults to min value
-	double out = min;
+    // Output defaults to min value
+    double out = min;
 
-	// Output becomes max value for second half of period
-	if (time >= period / 2.0) {
-		out = max;
-	}
+    // Output becomes max value for second half of period
+    if (time >= period / 2.0) {
+        out = max;
+    }
 
     return out;
 }

--- a/sdk/bare/common/sys/injection.c
+++ b/sdk/bare/common/sys/injection.c
@@ -82,6 +82,19 @@ static inline double _triangle(double min, double max, double period, double tim
     return out;
 }
 
+static inline double _square(double min, double max, double period, double time)
+{
+	// Output defaults to min value
+	double out = min;
+
+	// Output becomes max value for second half of period
+	if (time >= period / 2.0) {
+		out = max;
+	}
+
+    return out;
+}
+
 void injection_init(void)
 {
     cmd_inj_register();
@@ -208,6 +221,17 @@ void injection_inj(double *output, inj_ctx_t *ctx, double Ts)
         break;
     }
 
+    case SQUARE:
+    {
+        ctx->curr_time += Ts;
+        if (ctx->curr_time >= ctx->square.period) {
+            ctx->curr_time = 0.0;
+        }
+
+        value = _square(ctx->square.valueMin, ctx->square.valueMax, ctx->square.period, ctx->curr_time);
+        break;
+    }
+
     case NONE:
     default:
         // Injection function not set by user,
@@ -302,6 +326,16 @@ void injection_triangle(inj_ctx_t *ctx, inj_op_e op, double valueMin, double val
     ctx->triangle.valueMin = valueMin;
     ctx->triangle.valueMax = valueMax;
     ctx->triangle.period = period;
+}
+
+void injection_square(inj_ctx_t *ctx, inj_op_e op, double valueMin, double valueMax, double period)
+{
+    ctx->inj_func = SQUARE;
+    ctx->operation = op;
+    ctx->curr_time = 0.0;
+    ctx->square.valueMin = valueMin;
+    ctx->square.valueMax = valueMax;
+    ctx->square.period = period;
 }
 
 // ***************************

--- a/sdk/bare/common/sys/injection.h
+++ b/sdk/bare/common/sys/injection.h
@@ -8,6 +8,7 @@ typedef enum inj_func_e {
     NOISE,
     CHIRP,
     TRIANGLE,
+    SQUARE,
     NONE,
 } inj_func_e;
 
@@ -39,6 +40,12 @@ typedef struct inj_func_triangle_t {
     double period;
 } inj_func_triangle_t;
 
+typedef struct inj_func_square_t {
+    double valueMin;
+    double valueMax;
+    double period;
+} inj_func_square_t;
+
 #define INJ_MAX_NAME_LENGTH (24)
 
 typedef struct inj_ctx_t {
@@ -54,6 +61,7 @@ typedef struct inj_ctx_t {
     inj_func_noise_t noise;
     inj_func_chirp_t chirp;
     inj_func_triangle_t triangle;
+    inj_func_square_t square;
 
     double curr_time;
 } inj_ctx_t;
@@ -73,6 +81,7 @@ void injection_const(inj_ctx_t *ctx, inj_op_e op, double value);
 void injection_noise(inj_ctx_t *ctx, inj_op_e op, double gain, double offset);
 void injection_chirp(inj_ctx_t *ctx, inj_op_e op, double gain, double freqMin, double freqMax, double period);
 void injection_triangle(inj_ctx_t *ctx, inj_op_e op, double valueMin, double valueMax, double period);
+void injection_square(inj_ctx_t *ctx, inj_op_e op, double valueMin, double valueMax, double period);
 
 inj_ctx_t *injection_find_ctx_by_name(char *name);
 


### PR DESCRIPTION
This PR introduces a new injection signal type: the `square` wave.

This works very similarly to the `triangle` injection which is already implemented. The user defines the square wave signal `min` and `max` values, along with the `period`.
