### PR TITLE
Fix chirp injection signal function generator

### DIFF
--- a/sdk/bare/common/sys/injection.c
+++ b/sdk/bare/common/sys/injection.c
@@ -20,23 +20,29 @@ static int next_ctx_id = 0;
 // Chirp function
 //
 // Generates the chirp signal value given:
-// - time: current time instant
-// - w1:   low freq (rad)
-// - w2:   high freq (rad)
-// - A:    amplitude
-// - T:    time period
-static inline double _chirp(double w1, double w2, double A, double T, double time)
+// - time:   current time instant
+// - w1:     low freq (rad/s)
+// - w2:     high freq (rad/s)
+// - A:      amplitude
+// - period: time period (sec)
+static inline double _chirp(double w1, double w2, double A, double period, double time)
 {
-    double slope = (w2 - w1) / (T / 2.0);
-
-    double freq;
-    if (time < T / 2.0) {
-        freq = slope * time + w1;
+	double half_period = T / 2.0;
+    double freq_slope = (w2 - w1) / half_period;
+	
+    double mytime;
+    double mygain;
+    if (time < half_period) {
+		mytime = time;
+		mygain = 1.0;
     } else {
-        freq = -1.0 * slope * (time - (T / 2.0)) + w2;
-    }
-
-    double out = A * cos(freq * time);
+		mytime = period - time;
+		mygain = -1.0;
+	}
+	
+	double freq = freq_slope * mytime/2.0 + w1;
+    double out = A * mygain * sin(freq * mytime);
+	
     return out;
 }
 

--- a/sdk/bare/common/sys/injection.c
+++ b/sdk/bare/common/sys/injection.c
@@ -27,22 +27,22 @@ static int next_ctx_id = 0;
 // - period: time period (sec)
 static inline double _chirp(double w1, double w2, double A, double period, double time)
 {
-	double half_period = T / 2.0;
+    double half_period = T / 2.0;
     double freq_slope = (w2 - w1) / half_period;
-	
+
     double mytime;
     double mygain;
     if (time < half_period) {
-		mytime = time;
-		mygain = 1.0;
+        mytime = time;
+        mygain = 1.0;
     } else {
-		mytime = period - time;
-		mygain = -1.0;
-	}
-	
-	double freq = freq_slope * mytime/2.0 + w1;
+        mytime = period - time;
+        mygain = -1.0;
+    }
+
+    double freq = freq_slope * mytime / 2.0 + w1;
     double out = A * mygain * sin(freq * mytime);
-	
+
     return out;
 }
 

--- a/sdk/bare/common/sys/injection.c
+++ b/sdk/bare/common/sys/injection.c
@@ -27,7 +27,7 @@ static int next_ctx_id = 0;
 // - period: time period (sec)
 static inline double _chirp(double w1, double w2, double A, double period, double time)
 {
-    double half_period = T / 2.0;
+    double half_period = period / 2.0;
     double freq_slope = (w2 - w1) / half_period;
 
     double mytime;


### PR DESCRIPTION
I define the ideal chirp signal injection capability as only exciting the specified frequencies. For example, if I inject a chirp from 10-100Hz, I expect the only excited output is exactly that range. However, it is actually pretty challenging to generate a back-to-back chirp signal which has no discontinuities -- the phase has to line up at all changes in frequency slope.

The chirp signal injection has never worked very well; it seems to not inject the right frequencies, and seems to always be discontinuous between freq slope changes.

This PR is an attempt to fix the `chirp` injection function and provide a MATLAB script to evaluate it.

Fixes: #217 