### PR TITLE
Add auto find log variables by regex

### DIFF
--- a/scripts/AMDC_Logger.py
+++ b/scripts/AMDC_Logger.py
@@ -135,7 +135,7 @@ class AMDC_Logger():
         #for var in self.log_vars:
         #    self.clear(var)
         
-    def auto_find_vars(self, root):
+    def auto_find_vars(self, root, regex=None):
         
         log_vars = []
         log_types = []
@@ -149,21 +149,21 @@ class AMDC_Logger():
                     for var, tp in zip(lv, lt):
                         log_vars.append(var)
                         log_types.append(tp)
-                        
-        return log_vars, log_types
-    
-    def auto_find_vars_by_regex(self, root, regex):
-        names, types = self.auto_find_vars(root)
 
-        output_vars = []
-        output_types = []
+        if regex is None:
+            # Return all
+            return log_vars, log_types
+        else:
+            # Filter by user-provided regex
+            output_vars = []
+            output_types = []
 
-        for i,n in enumerate(names):
-            if re.search(regex, n) is not None:
-                output_vars.append(names[i])
-                output_types.append(types[i])
+            for i,n in enumerate(log_vars):
+                if re.search(regex, n) is not None:
+                    output_vars.append(log_vars[i])
+                    output_types.append(log_types[i])
 
-        return output_vars, output_types
+            return output_vars, output_types
     
     def start(self):
         self.amdc.cmd('log start')

--- a/scripts/AMDC_Logger.py
+++ b/scripts/AMDC_Logger.py
@@ -7,6 +7,7 @@ import os
 import datetime
 import struct
 import binascii
+import re
 
 #########################################################
 # Title:       AMDC Logging code
@@ -150,7 +151,20 @@ class AMDC_Logger():
                         log_types.append(tp)
                         
         return log_vars, log_types
-        
+    
+    def auto_find_vars_by_regex(self, root, regex):
+        names, types = self.auto_find_vars(root)
+
+        output_vars = []
+        output_types = []
+
+        for i,n in enumerate(names):
+            if re.search(regex, n) is not None:
+                output_vars.append(names[i])
+                output_types.append(types[i])
+
+        return output_vars, output_types
+    
     def start(self):
         self.amdc.cmd('log start')
         


### PR DESCRIPTION
Closes #233 

This PR adds the ability to easily find (i.e. register) many log variables using [Regular Expressions](https://en.wikipedia.org/wiki/Regular_expression) (regex).

## Example Usage:

Consider a system with 6 current signals to log, `current_1..6`.

Instead of writing:

```python
vars_to_log = 'current_1 current_2 current_3 current_4 current_5 current_6'
logger.register(vars_to_log)
```

you can explore all your source code and automatically find all log variables that match a given regex:

```python
vars_to_log = logger.auto_find_vars(root, regex='current_*')[0]
logger.register(vars_to_log)
```

This can be very helpful as the number of log variables grows with complex control algorithms.


