### PR TITLE
Fix pwm_enable_hw() driver function

### DIFF
--- a/sdk/app_cpu1/common/drv/pwm.c
+++ b/sdk/app_cpu1/common/drv/pwm.c
@@ -120,20 +120,20 @@ static bool is_pwm_enable_hw_enabled = false;
 
 int pwm_enable_hw(bool en)
 {
-	int err = FAILURE;
+    int err = FAILURE;
 
     if (en) {
-    	if (!is_pwm_enable_hw_enabled) {
-    		XGpioPs_WritePin(&Gpio, pin_PS_DRIVE_EN_MIO, 1);
-    		is_pwm_enable_hw_enabled = true;
-    		err = SUCCESS;
-    	}
+        if (!is_pwm_enable_hw_enabled) {
+            XGpioPs_WritePin(&Gpio, pin_PS_DRIVE_EN_MIO, 1);
+            is_pwm_enable_hw_enabled = true;
+            err = SUCCESS;
+        }
     } else {
-    	if (is_pwm_enable_hw_enabled) {
-    		XGpioPs_WritePin(&Gpio, pin_PS_DRIVE_EN_MIO, 0);
-    		is_pwm_enable_hw_enabled = false;
-    		err = SUCCESS;
-    	}
+        if (is_pwm_enable_hw_enabled) {
+            XGpioPs_WritePin(&Gpio, pin_PS_DRIVE_EN_MIO, 0);
+            is_pwm_enable_hw_enabled = false;
+            err = SUCCESS;
+        }
     }
 
     return err;

--- a/sdk/app_cpu1/common/drv/pwm.c
+++ b/sdk/app_cpu1/common/drv/pwm.c
@@ -113,11 +113,12 @@ void pwm_set_all_rst(uint8_t rst)
     Xil_Out32(PWM_BASE_ADDR + (27 * sizeof(uint32_t)), value);
 }
 
-int pwm_enable_hw(bool en)
+void pwm_enable_hw(bool en)
 {
     if (en) {
-
+        XGpioPs_WritePin(&Gpio, pin_PS_DRIVE_EN_MIO, 1);
     } else {
+        XGpioPs_WritePin(&Gpio, pin_PS_DRIVE_EN_MIO, 0);
     }
 }
 

--- a/sdk/app_cpu1/common/drv/pwm.c
+++ b/sdk/app_cpu1/common/drv/pwm.c
@@ -113,14 +113,33 @@ void pwm_set_all_rst(uint8_t rst)
     Xil_Out32(PWM_BASE_ADDR + (27 * sizeof(uint32_t)), value);
 }
 
-void pwm_enable_hw(bool en)
+// Hardware disabling of PWM was added to REV E hardware
+#if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_E
+
+static bool is_pwm_enable_hw_enabled = false;
+
+int pwm_enable_hw(bool en)
 {
+	int err = FAILURE;
+
     if (en) {
-        XGpioPs_WritePin(&Gpio, pin_PS_DRIVE_EN_MIO, 1);
+    	if (!is_pwm_enable_hw_enabled) {
+    		XGpioPs_WritePin(&Gpio, pin_PS_DRIVE_EN_MIO, 1);
+    		is_pwm_enable_hw_enabled = true;
+    		err = SUCCESS;
+    	}
     } else {
-        XGpioPs_WritePin(&Gpio, pin_PS_DRIVE_EN_MIO, 0);
+    	if (is_pwm_enable_hw_enabled) {
+    		XGpioPs_WritePin(&Gpio, pin_PS_DRIVE_EN_MIO, 0);
+    		is_pwm_enable_hw_enabled = false;
+    		err = SUCCESS;
+    	}
     }
+
+    return err;
 }
+
+#endif
 
 int pwm_enable(void)
 {

--- a/sdk/app_cpu1/common/drv/pwm.h
+++ b/sdk/app_cpu1/common/drv/pwm.h
@@ -60,7 +60,7 @@ void pwm_init(void);
 void pwm_toggle_reset(void);
 void pwm_set_all_rst(uint8_t rst);
 
-int pwm_enable_hw(bool en);
+void pwm_enable_hw(bool en);
 
 int pwm_enable(void);
 int pwm_disable(void);

--- a/sdk/app_cpu1/common/drv/pwm.h
+++ b/sdk/app_cpu1/common/drv/pwm.h
@@ -60,7 +60,9 @@ void pwm_init(void);
 void pwm_toggle_reset(void);
 void pwm_set_all_rst(uint8_t rst);
 
-void pwm_enable_hw(bool en);
+#if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_E
+int pwm_enable_hw(bool en);
+#endif
 
 int pwm_enable(void);
 int pwm_disable(void);

--- a/sdk/app_cpu1/common/sys/cmd/cmd_hw.c
+++ b/sdk/app_cpu1/common/sys/cmd/cmd_hw.c
@@ -48,6 +48,9 @@ int cmd_hw(int argc, char **argv)
     // Handle 'pwm' sub-command
     if (argc >= 2 && STREQ("pwm", argv[1])) {
         if (argc == 3 && STREQ("on", argv[2])) {
+#if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_E
+        	pwm_enable_hw(true);
+#endif
             if (pwm_enable() != SUCCESS) {
                 return CMD_FAILURE;
             }
@@ -56,6 +59,9 @@ int cmd_hw(int argc, char **argv)
         }
 
         if (argc == 3 && STREQ("off", argv[2])) {
+#if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_E
+        	pwm_enable_hw(false);
+#endif
             if (pwm_disable() != SUCCESS) {
                 return CMD_FAILURE;
             }

--- a/sdk/app_cpu1/common/sys/cmd/cmd_hw.c
+++ b/sdk/app_cpu1/common/sys/cmd/cmd_hw.c
@@ -51,7 +51,7 @@ int cmd_hw(int argc, char **argv)
     if (argc >= 2 && STREQ("pwm", argv[1])) {
         if (argc == 3 && STREQ("on", argv[2])) {
 #if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_E
-        	pwm_enable_hw(true);
+            pwm_enable_hw(true);
 #endif
             if (pwm_enable() != SUCCESS) {
                 return CMD_FAILURE;
@@ -62,7 +62,7 @@ int cmd_hw(int argc, char **argv)
 
         if (argc == 3 && STREQ("off", argv[2])) {
 #if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_E
-        	pwm_enable_hw(false);
+            pwm_enable_hw(false);
 #endif
             if (pwm_disable() != SUCCESS) {
                 return CMD_FAILURE;

--- a/sdk/app_cpu1/common/sys/cmd/cmd_hw.c
+++ b/sdk/app_cpu1/common/sys/cmd/cmd_hw.c
@@ -55,6 +55,7 @@ int cmd_hw(int argc, char **argv)
             // so that the first cycle has correct duty
             pwm_enable_hw(true);
 #endif
+
             if (pwm_enable() != SUCCESS) {
                 return CMD_FAILURE;
             }
@@ -72,7 +73,7 @@ int cmd_hw(int argc, char **argv)
             // so that the last cycle has correct duty
             pwm_enable_hw(false);
 #endif
-            
+
             return CMD_SUCCESS;
         }
 

--- a/sdk/app_cpu1/common/sys/cmd/cmd_hw.c
+++ b/sdk/app_cpu1/common/sys/cmd/cmd_hw.c
@@ -51,6 +51,8 @@ int cmd_hw(int argc, char **argv)
     if (argc >= 2 && STREQ("pwm", argv[1])) {
         if (argc == 3 && STREQ("on", argv[2])) {
 #if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_E
+            // Turn on PWM hardware before enabling
+            // so that the first cycle has correct duty
             pwm_enable_hw(true);
 #endif
             if (pwm_enable() != SUCCESS) {
@@ -61,13 +63,16 @@ int cmd_hw(int argc, char **argv)
         }
 
         if (argc == 3 && STREQ("off", argv[2])) {
-#if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_E
-            pwm_enable_hw(false);
-#endif
             if (pwm_disable() != SUCCESS) {
                 return CMD_FAILURE;
             }
 
+#if USER_CONFIG_HARDWARE_TARGET == AMDC_REV_E
+            // Turn off PWM hardware after disabling
+            // so that the last cycle has correct duty
+            pwm_enable_hw(false);
+#endif
+            
             return CMD_SUCCESS;
         }
 


### PR DESCRIPTION
Closes #224 

Only compile `pwm_enable_hw()` for REV E hardware--the feature does not exist for REV D.

Also ensures the driver function outputs an error code.