### PR TITLE
Add ramp injection functionality

### DIFF
--- a/sdk/app_cpu1/common/sys/cmd/cmd_inj.c
+++ b/sdk/app_cpu1/common/sys/cmd/cmd_inj.c
@@ -221,6 +221,37 @@ int cmd_inj(int argc, char **argv)
         return CMD_SUCCESS;
     }
 
+    // Handle 'inj ramp ...' command
+	if (argc == 7 && STREQ("ramp", argv[1])) {
+		// Parse out name and convert to injection context
+		inj_ctx_t *ctx = injection_find_ctx_by_name(argv[2]);
+		if (ctx == NULL) {
+			return CMD_INVALID_ARGUMENTS;
+		}
+
+		// Parse out operation
+		inj_op_e op;
+		if (_parse_op(argv[3], &op) != 0) {
+			return CMD_INVALID_ARGUMENTS;
+		}
+
+		// Pull out valueMin argument
+		double valueMin = strtod(argv[4], NULL);
+
+		// Pull out valueMax argument
+		double valueMax = strtod(argv[5], NULL);
+
+		// Pull out period argument
+		double period = strtod(argv[6], NULL);
+		if (period < 0.0) {
+			return CMD_INVALID_ARGUMENTS;
+		}
+
+		injection_ramp(ctx, op, valueMin, valueMax, period);
+
+		return CMD_SUCCESS;
+	}
+
     return CMD_INVALID_ARGUMENTS;
 }
 

--- a/sdk/app_cpu1/common/sys/cmd/cmd_inj.c
+++ b/sdk/app_cpu1/common/sys/cmd/cmd_inj.c
@@ -222,35 +222,35 @@ int cmd_inj(int argc, char **argv)
     }
 
     // Handle 'inj ramp ...' command
-	if (argc == 7 && STREQ("ramp", argv[1])) {
-		// Parse out name and convert to injection context
-		inj_ctx_t *ctx = injection_find_ctx_by_name(argv[2]);
-		if (ctx == NULL) {
-			return CMD_INVALID_ARGUMENTS;
-		}
+    if (argc == 7 && STREQ("ramp", argv[1])) {
+        // Parse out name and convert to injection context
+        inj_ctx_t *ctx = injection_find_ctx_by_name(argv[2]);
+        if (ctx == NULL) {
+            return CMD_INVALID_ARGUMENTS;
+        }
 
-		// Parse out operation
-		inj_op_e op;
-		if (_parse_op(argv[3], &op) != 0) {
-			return CMD_INVALID_ARGUMENTS;
-		}
+        // Parse out operation
+        inj_op_e op;
+        if (_parse_op(argv[3], &op) != 0) {
+            return CMD_INVALID_ARGUMENTS;
+        }
 
-		// Pull out valueMin argument
-		double valueMin = strtod(argv[4], NULL);
+        // Pull out valueMin argument
+        double valueMin = strtod(argv[4], NULL);
 
-		// Pull out valueMax argument
-		double valueMax = strtod(argv[5], NULL);
+        // Pull out valueMax argument
+        double valueMax = strtod(argv[5], NULL);
 
-		// Pull out period argument
-		double period = strtod(argv[6], NULL);
-		if (period < 0.0) {
-			return CMD_INVALID_ARGUMENTS;
-		}
+        // Pull out period argument
+        double period = strtod(argv[6], NULL);
+        if (period < 0.0) {
+            return CMD_INVALID_ARGUMENTS;
+        }
 
-		injection_ramp(ctx, op, valueMin, valueMax, period);
+        injection_ramp(ctx, op, valueMin, valueMax, period);
 
-		return CMD_SUCCESS;
-	}
+        return CMD_SUCCESS;
+    }
 
     return CMD_INVALID_ARGUMENTS;
 }

--- a/sdk/app_cpu1/common/sys/injection.c
+++ b/sdk/app_cpu1/common/sys/injection.c
@@ -115,7 +115,7 @@ static inline double _ramp(double min, double max, double period, double time)
     double out;
     // Calculate slope
     double m_pos = (max - min) / (period);
-    // Caclculate output	
+    // Caclculate output
     out = m_pos * time + min;
 
     return out;

--- a/sdk/app_cpu1/common/sys/injection.c
+++ b/sdk/app_cpu1/common/sys/injection.c
@@ -112,20 +112,11 @@ static inline double _square(double min, double max, double period, double time)
 
 static inline double _ramp(double min, double max, double period, double time)
 {
-    // S1: increases to max at t = T,
-    // S2: resets to min after
-
-    double out = min;
+    double out;
     // Calculate slope
     double m_pos = (max - min) / (period);
-    if (0.0 <= time && time < period) {
-        // State S1
-        out = m_pos * time + min;
-    } else {
-        // State S2
-        // y = m(x - x1) + y1
-        out = min;
-    }
+    // Caclculate output	
+    out = m_pos * time + min;
 
     return out;
 }
@@ -241,7 +232,7 @@ void injection_inj(double *output, inj_ctx_t *ctx, double Ts)
     {
         ctx->curr_time += Ts;
         if (ctx->curr_time >= ctx->chirp.period) {
-            ctx->curr_time = 0.0;
+            ctx->curr_time -= ctx->ramp.period;
         }
 
         value = _chirp(
@@ -253,7 +244,7 @@ void injection_inj(double *output, inj_ctx_t *ctx, double Ts)
     {
         ctx->curr_time += Ts;
         if (ctx->curr_time >= ctx->triangle.period) {
-            ctx->curr_time = 0.0;
+            ctx->curr_time -= ctx->ramp.period;
         }
 
         value = _triangle(ctx->triangle.valueMin, ctx->triangle.valueMax, ctx->triangle.period, ctx->curr_time);
@@ -264,7 +255,7 @@ void injection_inj(double *output, inj_ctx_t *ctx, double Ts)
     {
         ctx->curr_time += Ts;
         if (ctx->curr_time >= ctx->square.period) {
-            ctx->curr_time = 0.0;
+            ctx->curr_time -= ctx->ramp.period;
         }
 
         value = _square(ctx->square.valueMin, ctx->square.valueMax, ctx->square.period, ctx->curr_time);
@@ -275,7 +266,7 @@ void injection_inj(double *output, inj_ctx_t *ctx, double Ts)
     {
         ctx->curr_time += Ts;
         if (ctx->curr_time >= ctx->ramp.period) {
-            ctx->curr_time = 0.0;
+            ctx->curr_time -= ctx->ramp.period;
         }
 
         value = _ramp(ctx->ramp.valueMin, ctx->ramp.valueMax, ctx->ramp.period, ctx->curr_time);

--- a/sdk/app_cpu1/common/sys/injection.c
+++ b/sdk/app_cpu1/common/sys/injection.c
@@ -232,7 +232,7 @@ void injection_inj(double *output, inj_ctx_t *ctx, double Ts)
     {
         ctx->curr_time += Ts;
         if (ctx->curr_time >= ctx->chirp.period) {
-            ctx->curr_time -= ctx->ramp.period;
+            ctx->curr_time -= ctx->chirp.period;
         }
 
         value = _chirp(
@@ -244,7 +244,7 @@ void injection_inj(double *output, inj_ctx_t *ctx, double Ts)
     {
         ctx->curr_time += Ts;
         if (ctx->curr_time >= ctx->triangle.period) {
-            ctx->curr_time -= ctx->ramp.period;
+            ctx->curr_time -= ctx->triangle.period;
         }
 
         value = _triangle(ctx->triangle.valueMin, ctx->triangle.valueMax, ctx->triangle.period, ctx->curr_time);
@@ -255,7 +255,7 @@ void injection_inj(double *output, inj_ctx_t *ctx, double Ts)
     {
         ctx->curr_time += Ts;
         if (ctx->curr_time >= ctx->square.period) {
-            ctx->curr_time -= ctx->ramp.period;
+            ctx->curr_time -= ctx->square.period;
         }
 
         value = _square(ctx->square.valueMin, ctx->square.valueMax, ctx->square.period, ctx->curr_time);

--- a/sdk/app_cpu1/common/sys/injection.c
+++ b/sdk/app_cpu1/common/sys/injection.c
@@ -423,7 +423,7 @@ void state_machine_list_callback(void *arg)
     switch (ctx->state) {
     case LISTING:
         // Print entry
-        debug_printf("%s\r\n", ctx->curr->name);
+        cmd_resp_printf("%s\r\n", ctx->curr->name);
 
         // Move to next entry
         ctx->curr = ctx->curr->next;

--- a/sdk/app_cpu1/common/sys/injection.c
+++ b/sdk/app_cpu1/common/sys/injection.c
@@ -121,8 +121,7 @@ static inline double _ramp(double min, double max, double period, double time)
     if (0.0 <= time && time < period) {
         // State S1
         out = m_pos * time + min;
-    }
-    else {
+    } else {
         // State S2
         // y = m(x - x1) + y1
         out = min;

--- a/sdk/app_cpu1/common/sys/injection.c
+++ b/sdk/app_cpu1/common/sys/injection.c
@@ -130,7 +130,6 @@ static inline double _ramp(double min, double max, double period, double time)
     return out;
 }
 
-
 void injection_init(void)
 {
     cmd_inj_register();
@@ -274,14 +273,14 @@ void injection_inj(double *output, inj_ctx_t *ctx, double Ts)
 
     case RAMP:
     {
-		ctx->curr_time += Ts;
-		if (ctx->curr_time >= ctx->ramp.period) {
-			ctx->curr_time = 0.0;
-		}
+        ctx->curr_time += Ts;
+        if (ctx->curr_time >= ctx->ramp.period) {
+            ctx->curr_time = 0.0;
+        }
 
-		value = _ramp(ctx->ramp.valueMin, ctx->ramp.valueMax, ctx->ramp.period, ctx->curr_time);
-		break;
-	}
+        value = _ramp(ctx->ramp.valueMin, ctx->ramp.valueMax, ctx->ramp.period, ctx->curr_time);
+        break;
+    }
 
     case NONE:
     default:

--- a/sdk/app_cpu1/common/sys/injection.c
+++ b/sdk/app_cpu1/common/sys/injection.c
@@ -115,7 +115,8 @@ static inline double _ramp(double min, double max, double period, double time)
     double out;
     // Calculate slope
     double m_pos = (max - min) / (period);
-    // Caclculate output
+
+    // Calculate output
     out = m_pos * time + min;
 
     return out;

--- a/sdk/app_cpu1/common/sys/injection.h
+++ b/sdk/app_cpu1/common/sys/injection.h
@@ -70,7 +70,7 @@ typedef struct inj_ctx_t {
     inj_func_triangle_t triangle;
     inj_func_square_t square;
     inj_func_ramp_t ramp;
-    
+
     double curr_time;
 } inj_ctx_t;
 

--- a/sdk/app_cpu1/common/sys/injection.h
+++ b/sdk/app_cpu1/common/sys/injection.h
@@ -70,6 +70,7 @@ typedef struct inj_ctx_t {
     inj_func_triangle_t triangle;
     inj_func_square_t square;
     inj_func_ramp_t ramp;
+    
     double curr_time;
 } inj_ctx_t;
 

--- a/sdk/app_cpu1/common/sys/injection.h
+++ b/sdk/app_cpu1/common/sys/injection.h
@@ -9,7 +9,7 @@ typedef enum inj_func_e {
     CHIRP,
     TRIANGLE,
     SQUARE,
-	RAMP,
+    RAMP,
     NONE,
 } inj_func_e;
 

--- a/sdk/app_cpu1/common/sys/injection.h
+++ b/sdk/app_cpu1/common/sys/injection.h
@@ -9,6 +9,7 @@ typedef enum inj_func_e {
     CHIRP,
     TRIANGLE,
     SQUARE,
+	RAMP,
     NONE,
 } inj_func_e;
 
@@ -46,6 +47,12 @@ typedef struct inj_func_square_t {
     double period;
 } inj_func_square_t;
 
+typedef struct inj_func_ramp_t {
+    double valueMin;
+    double valueMax;
+    double period;
+} inj_func_ramp_t;
+
 #define INJ_MAX_NAME_LENGTH (24)
 
 typedef struct inj_ctx_t {
@@ -62,7 +69,7 @@ typedef struct inj_ctx_t {
     inj_func_chirp_t chirp;
     inj_func_triangle_t triangle;
     inj_func_square_t square;
-
+    inj_func_ramp_t ramp;
     double curr_time;
 } inj_ctx_t;
 
@@ -82,6 +89,7 @@ void injection_noise(inj_ctx_t *ctx, inj_op_e op, double gain, double offset);
 void injection_chirp(inj_ctx_t *ctx, inj_op_e op, double gain, double freqMin, double freqMax, double period);
 void injection_triangle(inj_ctx_t *ctx, inj_op_e op, double valueMin, double valueMax, double period);
 void injection_square(inj_ctx_t *ctx, inj_op_e op, double valueMin, double valueMax, double period);
+void injection_ramp(inj_ctx_t *ctx, inj_op_e op, double valueMin, double valueMax, double period);
 
 inj_ctx_t *injection_find_ctx_by_name(char *name);
 


### PR DESCRIPTION
This PR addresses issue #261 by adding a `ramp` function to `sys/injection.c`, along with all the supporting functions that go with it. Will be useful to emulate encoders while testing with hardware.

The code was tested on an AMDC RevD board to prove that it indeed does work as expected. In order to test out this functionality, the injection command was logged on the AMDC. The command passed to the AMDC was `inj ramp theta* set 0 360 0.1`. The resulting `theta*` waveform, logged at 1 kHz, is shown below. 

![ramp](https://user-images.githubusercontent.com/70265814/159811747-50214d2a-7c38-49e3-991d-7990361a0ef3.png)
