### PR TITLE
Add support for encoder pulse counts that are not power of two

### DIFF
--- a/ip_repo/amdc_encoder_1.0/src/encoder.v
+++ b/ip_repo/amdc_encoder_1.0/src/encoder.v
@@ -9,7 +9,7 @@
 // and sum them into a binary counter register.
 //
 // Z is used to provide single revolution position via `position` output
-// `position` ranges between 0 and pulses_per_rev_bits
+// `position` ranges between 0 and pulses_per_rev - 1
 //
 module encoder(clk, rst_n, A, B, Z, counter, position, pulses_per_rev);
 
@@ -186,7 +186,7 @@ end
 // *****************************
 
 wire [31:0] MAX_POS;
-assign MAX_POS = pulses_per_rev;
+assign MAX_POS = pulses_per_rev - 32'd1;
 
 // Find rising edge of Z
 wire z_rise;

--- a/ip_repo/amdc_encoder_1.0/src/encoder.v
+++ b/ip_repo/amdc_encoder_1.0/src/encoder.v
@@ -9,15 +9,15 @@
 // and sum them into a binary counter register.
 //
 // Z is used to provide single revolution position via `position` output
-// `position` ranges between 0 and (2 ^ pulses_per_rev_bits) - 1
+// `position` ranges between 0 and pulses_per_rev_bits
 //
-module encoder(clk, rst_n, A, B, Z, counter, position, pulses_per_rev_bits);
+module encoder(clk, rst_n, A, B, Z, counter, position, pulses_per_rev);
 
 input A, B, Z;
 input clk;
 input rst_n;
 
-input [31:0] pulses_per_rev_bits;
+input [31:0] pulses_per_rev;
 
 output wire [31:0] counter;
 output wire [31:0] position;
@@ -180,13 +180,13 @@ end
 //
 //       Typically ~12-bit (2^12 = 4096 pulses per rev).
 //       
-//       Stored in `pulses_per_rev_bits` input signal.
+//       Stored in `pulses_per_rev` input signal.
 //
 //       Max pulses per rev: 2^32
 // *****************************
 
 wire [31:0] MAX_POS;
-assign MAX_POS = (32'd1 << pulses_per_rev_bits) - 32'd1;
+assign MAX_POS = pulses_per_rev;
 
 // Find rising edge of Z
 wire z_rise;

--- a/sdk/app_cpu1/common/drv/encoder.c
+++ b/sdk/app_cpu1/common/drv/encoder.c
@@ -2,8 +2,8 @@
 #include "sys/defines.h"
 #include "sys/scheduler.h"
 #include "xil_io.h"
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 #define ENCODER_BASE_ADDR (0x43C10000)
 
 void encoder_init(void)
@@ -15,7 +15,7 @@ void encoder_init(void)
 void encoder_set_pulses_per_rev_bits(uint32_t bits)
 {
 	printf("ENC:\tSetting pulses per rev bits = %ld...\n", bits);
-    encoder_set_pulses_per_rev(pow((uint32_t)2, bits));
+    encoder_set_pulses_per_rev(pow((uint32_t) 2, bits));
 }
 
 void encoder_set_pulses_per_rev(uint32_t pulses)

--- a/sdk/app_cpu1/common/drv/encoder.c
+++ b/sdk/app_cpu1/common/drv/encoder.c
@@ -15,7 +15,7 @@ void encoder_init(void)
 void encoder_set_pulses_per_rev_bits(uint32_t bits)
 {
     printf("ENC:\tSetting pulses per rev bits = %ld...\n", bits);
-    encoder_set_pulses_per_rev(pow((uint32_t) 2, bits));
+    encoder_set_pulses_per_rev(1 << bits));
 }
 
 void encoder_set_pulses_per_rev(uint32_t pulses)

--- a/sdk/app_cpu1/common/drv/encoder.c
+++ b/sdk/app_cpu1/common/drv/encoder.c
@@ -15,7 +15,7 @@ void encoder_init(void)
 void encoder_set_pulses_per_rev_bits(uint32_t bits)
 {
     printf("ENC:\tSetting pulses per rev bits = %ld...\n", bits);
-    encoder_set_pulses_per_rev(1 << bits));
+    encoder_set_pulses_per_rev(1 << bits);
 }
 
 void encoder_set_pulses_per_rev(uint32_t pulses)

--- a/sdk/app_cpu1/common/drv/encoder.c
+++ b/sdk/app_cpu1/common/drv/encoder.c
@@ -14,7 +14,7 @@ void encoder_init(void)
 
 void encoder_set_pulses_per_rev_bits(uint32_t bits)
 {
-	printf("ENC:\tSetting pulses per rev bits = %ld...\n", bits);
+    printf("ENC:\tSetting pulses per rev bits = %ld...\n", bits);
     encoder_set_pulses_per_rev(pow((uint32_t) 2, bits));
 }
 

--- a/sdk/app_cpu1/common/drv/encoder.c
+++ b/sdk/app_cpu1/common/drv/encoder.c
@@ -3,7 +3,7 @@
 #include "sys/scheduler.h"
 #include "xil_io.h"
 #include <stdio.h>
-
+#include <math.h>
 #define ENCODER_BASE_ADDR (0x43C10000)
 
 void encoder_init(void)
@@ -14,9 +14,15 @@ void encoder_init(void)
 
 void encoder_set_pulses_per_rev_bits(uint32_t bits)
 {
-    printf("ENC:\tSetting pulses per rev bits = %ld...\n", bits);
+	printf("ENC:\tSetting pulses per rev bits = %ld...\n", bits);
+    encoder_set_pulses_per_rev(pow((uint32_t)2, bits));
+}
 
-    Xil_Out32(ENCODER_BASE_ADDR + 2 * sizeof(uint32_t), bits);
+void encoder_set_pulses_per_rev(uint32_t pulses)
+{
+    printf("ENC:\tSetting pulses per rev = %ld...\n", pulses);
+
+    Xil_Out32(ENCODER_BASE_ADDR + 2 * sizeof(uint32_t), pulses);
 }
 
 void encoder_get_steps(int32_t *steps)

--- a/sdk/app_cpu1/common/drv/encoder.h
+++ b/sdk/app_cpu1/common/drv/encoder.h
@@ -9,7 +9,7 @@
 void encoder_init(void);
 
 void encoder_set_pulses_per_rev_bits(uint32_t bits);
-
+void encoder_set_pulses_per_rev(uint32_t pulses);
 void encoder_get_steps(int32_t *steps);
 void encoder_get_position(uint32_t *position);
 


### PR DESCRIPTION
This is a draft pull request to update the encoder peripheral to support pulse counts that are not a power of 2.

This PR addresses issue #16 