### PR TITLE
Scheduler indicate problem task

### DIFF
--- a/sdk/app_cpu1/common/sys/scheduler.c
+++ b/sdk/app_cpu1/common/sys/scheduler.c
@@ -32,7 +32,7 @@ void scheduler_timer_isr(void *arg)
     if (tasks_running) {
         // Use raw printf so this goes directly to the UART device
         xil_printf("ERROR: OVERRUN SCHEDULER TIME QUANTUM!\r\n");
-        xil_printf("ERROR: PROBLEM TASK IS %s\n", running_task->name);
+        xil_printf("ERROR: CURRENT TASK IS %s\n", running_task->name);
 
         led_set_color(0, LED_COLOR_RED);
         led_set_color(1, LED_COLOR_RED);

--- a/sdk/app_cpu1/common/sys/scheduler.c
+++ b/sdk/app_cpu1/common/sys/scheduler.c
@@ -31,7 +31,8 @@ void scheduler_timer_isr(void *arg)
     // so if tasks are still running, we consumed too many cycles per slice
     if (tasks_running) {
         // Use raw printf so this goes directly to the UART device
-        xil_printf("ERROR: OVERRUN SCHEDULER TIME QUANTUM!\n");
+        xil_printf("ERROR: OVERRUN SCHEDULER TIME QUANTUM!\r\n");
+        xil_printf("ERROR: PROBLEM TASK IS %s\n", running_task->name);
 
         led_set_color(0, LED_COLOR_RED);
         led_set_color(1, LED_COLOR_RED);


### PR DESCRIPTION
The scheduler produces an error when a task exceeds the allotted time quantum and displays an error message on the terminal. This PR modifies that error message to include the problem task's name.