### PR TITLE
Add ability to read AMDS counter values

### DIFF
--- a/sdk/app_cpu1/common/drv/motherboard.c
+++ b/sdk/app_cpu1/common/drv/motherboard.c
@@ -107,12 +107,12 @@ void motherboard_get_counters(uint32_t base_addr, uint32_t *V, uint32_t *C, uint
     if (V != NULL) {
         *V = m_motherboard[MOTHERBOARD_DEFS_OFFSET_COUNT_VALID / 4];
     }
-    
+
     // Read C counter if user requested it
     if (C != NULL) {
         *V = m_motherboard[MOTHERBOARD_DEFS_OFFSET_COUNT_CORRUPT / 4];
     }
-    
+
     // Read T counter if user requested it
     if (T != NULL) {
         *V = m_motherboard[MOTHERBOARD_DEFS_OFFSET_COUNT_TIMEOUT / 4];

--- a/sdk/app_cpu1/common/drv/motherboard.c
+++ b/sdk/app_cpu1/common/drv/motherboard.c
@@ -98,4 +98,25 @@ void motherboard_print_counters(uint32_t base_addr)
     cmd_resp_printf("T: %08X\r\n", m_motherboard[MOTHERBOARD_DEFS_OFFSET_COUNT_TIMEOUT / 4]);
 }
 
+void motherboard_get_counters(uint32_t base_addr, uint32_t *V, uint32_t *C, uint32_t *T)
+{
+    // Create base address for IP
+    volatile uint32_t *m_motherboard = (volatile uint32_t *) base_addr;
+
+    // Read V counter if user requested it
+    if (V != NULL) {
+        *V = m_motherboard[MOTHERBOARD_DEFS_OFFSET_COUNT_VALID / 4];
+    }
+    
+    // Read C counter if user requested it
+    if (C != NULL) {
+        *V = m_motherboard[MOTHERBOARD_DEFS_OFFSET_COUNT_CORRUPT / 4];
+    }
+    
+    // Read T counter if user requested it
+    if (T != NULL) {
+        *V = m_motherboard[MOTHERBOARD_DEFS_OFFSET_COUNT_TIMEOUT / 4];
+    }
+}
+
 #endif // USER_CONFIG_ENABLE_MOTHERBOARD_SUPPORT

--- a/sdk/app_cpu1/common/drv/motherboard.c
+++ b/sdk/app_cpu1/common/drv/motherboard.c
@@ -110,12 +110,12 @@ void motherboard_get_counters(uint32_t base_addr, uint32_t *V, uint32_t *C, uint
 
     // Read C counter if user requested it
     if (C != NULL) {
-        *V = m_motherboard[MOTHERBOARD_DEFS_OFFSET_COUNT_CORRUPT / 4];
+        *C = m_motherboard[MOTHERBOARD_DEFS_OFFSET_COUNT_CORRUPT / 4];
     }
 
     // Read T counter if user requested it
     if (T != NULL) {
-        *V = m_motherboard[MOTHERBOARD_DEFS_OFFSET_COUNT_TIMEOUT / 4];
+        *T = m_motherboard[MOTHERBOARD_DEFS_OFFSET_COUNT_TIMEOUT / 4];
     }
 }
 

--- a/sdk/app_cpu1/common/drv/motherboard.h
+++ b/sdk/app_cpu1/common/drv/motherboard.h
@@ -83,5 +83,6 @@ int motherboard_get_data(uint32_t base_addr, mb_channel_e channel, int32_t *out)
 
 void motherboard_print_samples(uint32_t base_addr);
 void motherboard_print_counters(uint32_t base_addr);
+void motherboard_get_counters(uint32_t base_addr, uint32_t *V, uint32_t *C, uint32_t *T);
 
 #endif // MOTHERBOARD_H


### PR DESCRIPTION
Per #269, this PR provides a solution to read the AMDS counter values external to the driver code.

## Example usage

```c
#include "drv/motherboard.h"

// Read the V counter
uint32_t V_counter;
motherboard_get_counters(MOTHERBOARD_1_BASE_ADDR, &V_counter, NULL, NULL);

// Now, V_counter has the counter value from the driver
```