### PR TITLE
Add high priority task register function

### DIFF
--- a/sdk/app_cpu1/common/sys/scheduler.c
+++ b/sdk/app_cpu1/common/sys/scheduler.c
@@ -110,6 +110,29 @@ int scheduler_tcb_register(task_control_block_t *tcb)
     return SUCCESS;
 }
 
+int scheduler_tcb_register_high_priority(task_control_block_t *tcb)
+{
+    // Don't let clients re-register their tcb
+    if (tcb->is_registered) {
+        return FAILURE;
+    }
+
+    // Mark as registered
+    tcb->is_registered = true;
+
+    if (tasks == NULL) {
+        // There are no tasks in linked list
+        tasks = tcb;
+        tasks->next = NULL;
+    } else {
+        // Put new tcb at front of linked list
+        tcb->next = tasks;
+        tasks = tcb;
+    }
+
+    return SUCCESS;
+}
+
 int scheduler_tcb_unregister(task_control_block_t *tcb)
 {
     // Don't let clients unregister their already unregistered tcb

--- a/sdk/app_cpu1/common/sys/scheduler.h
+++ b/sdk/app_cpu1/common/sys/scheduler.h
@@ -49,7 +49,7 @@ void scheduler_run(void);
 void scheduler_tcb_init(
     task_control_block_t *tcb, task_callback_t callback, void *callback_arg, const char *name, uint32_t interval_usec);
 int scheduler_tcb_register(task_control_block_t *tcb);
-int scheduler_tcb_register_high_priority(task_control_block_t *tcb)
+int scheduler_tcb_register_high_priority(task_control_block_t *tcb);
 int scheduler_tcb_unregister(task_control_block_t *tcb);
 bool scheduler_tcb_is_registered(task_control_block_t *tcb);
 

--- a/sdk/app_cpu1/common/sys/scheduler.h
+++ b/sdk/app_cpu1/common/sys/scheduler.h
@@ -49,6 +49,7 @@ void scheduler_run(void);
 void scheduler_tcb_init(
     task_control_block_t *tcb, task_callback_t callback, void *callback_arg, const char *name, uint32_t interval_usec);
 int scheduler_tcb_register(task_control_block_t *tcb);
+int scheduler_tcb_register_high_priority(task_control_block_t *tcb)
 int scheduler_tcb_unregister(task_control_block_t *tcb);
 bool scheduler_tcb_is_registered(task_control_block_t *tcb);
 


### PR DESCRIPTION
Resolves #272 

After merging this PR, user control tasks should use: `scheduler_tcb_register_high_priority(tcb)` to help with jitter issues in the scheduler.