### PR TITLE
Synchronize Encoder Updates with PWM Carrier

### DIFF
--- a/hw/amdc_revd.bd
+++ b/hw/amdc_revd.bd
@@ -5,7 +5,8 @@
       "device": "xc7z030sbg485-1",
       "name": "amdc_revd",
       "synth_flow_mode": "Hierarchical",
-      "tool_version": "2019.1"
+      "tool_version": "2019.1",
+      "validated": "true"
     },
     "design_tree": {
       "control_timer_0": "",
@@ -93,11 +94,67 @@
     "interface_ports": {
       "DDR": {
         "mode": "Master",
-        "vlnv": "xilinx.com:interface:ddrx_rtl:1.0"
+        "vlnv": "xilinx.com:interface:ddrx_rtl:1.0",
+        "parameters": {
+          "AXI_ARBITRATION_SCHEME": {
+            "value": "TDM",
+            "value_src": "default"
+          },
+          "BURST_LENGTH": {
+            "value": "8",
+            "value_src": "default"
+          },
+          "CAN_DEBUG": {
+            "value": "false",
+            "value_src": "default"
+          },
+          "CAS_LATENCY": {
+            "value": "11",
+            "value_src": "default"
+          },
+          "CAS_WRITE_LATENCY": {
+            "value": "11",
+            "value_src": "default"
+          },
+          "CS_ENABLED": {
+            "value": "true",
+            "value_src": "default"
+          },
+          "DATA_MASK_ENABLED": {
+            "value": "true",
+            "value_src": "default"
+          },
+          "DATA_WIDTH": {
+            "value": "8",
+            "value_src": "default"
+          },
+          "MEMORY_TYPE": {
+            "value": "COMPONENTS",
+            "value_src": "default"
+          },
+          "MEM_ADDR_MAP": {
+            "value": "ROW_COLUMN_BANK",
+            "value_src": "default"
+          },
+          "SLOT": {
+            "value": "Single",
+            "value_src": "default"
+          },
+          "TIMEPERIOD_PS": {
+            "value": "1250",
+            "value_src": "default"
+          }
+        }
       },
       "FIXED_IO": {
         "mode": "Master",
-        "vlnv": "xilinx.com:display_processing_system7:fixedio_rtl:1.0"
+        "vlnv": "xilinx.com:display_processing_system7:fixedio_rtl:1.0",
+        "parameters": {
+          "CAN_DEBUG": {
+            "value": "false",
+            "value_src": "default"
+          }
+        }
       }
     },
     "ports": {
@@ -105,225 +162,547 @@
         "type": "data",
         "direction": "I",
         "left": "7",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "adc_clkout": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "adc_sck": {
         "type": "data",
-        "direction": "O"
+        "direction": "O",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "adc_cnv": {
         "type": "data",
-        "direction": "O"
+        "direction": "O",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "encoder_1z": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "encoder_2z": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "encoder_2b": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "encoder_2a": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "encoder_1a": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "encoder_1b": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter8_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter7_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter6_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter5_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter4_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter3_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter2_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter1_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "spi1_miso": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          },
+          "PortType": {
+            "value": "data",
+            "value_src": "default"
+          },
+          "PortType.PROP_SRC": {
+            "value": "false",
+            "value_src": "default"
+          }
+        }
       },
       "spi1_in": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "spi2_in": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "spi3_in": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "spi4_in": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "spi1_sclk": {
         "type": "clk",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "FREQ_HZ": {
+            "value": "100000000",
+            "value_src": "default"
+          },
+          "INSERT_VIP": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "PHASE": {
+            "value": "0.000",
+            "value_src": "default"
+          }
+        }
       },
       "spi1_nss": {
         "type": "data",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "spi1_mosi": {
         "type": "data",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "spi2_nss": {
         "type": "data",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "spi3_nss": {
         "type": "data",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "spi4_nss": {
         "type": "data",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "spi2_sclk": {
         "type": "clk",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "FREQ_HZ": {
+            "value": "100000000",
+            "value_src": "default"
+          },
+          "INSERT_VIP": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "PHASE": {
+            "value": "0.000",
+            "value_src": "default"
+          }
+        }
       },
       "spi3_sclk": {
         "type": "clk",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "FREQ_HZ": {
+            "value": "100000000",
+            "value_src": "default"
+          },
+          "INSERT_VIP": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "PHASE": {
+            "value": "0.000",
+            "value_src": "default"
+          }
+        }
       },
       "spi4_sclk": {
         "type": "clk",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "FREQ_HZ": {
+            "value": "100000000",
+            "value_src": "default"
+          },
+          "INSERT_VIP": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "PHASE": {
+            "value": "0.000",
+            "value_src": "default"
+          }
+        }
       },
       "spi2_mosi": {
         "type": "data",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "spi3_mosi": {
         "type": "data",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "spi4_mosi": {
         "type": "data",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "spi2_miso": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          },
+          "PortType": {
+            "value": "data",
+            "value_src": "default"
+          },
+          "PortType.PROP_SRC": {
+            "value": "false",
+            "value_src": "default"
+          }
+        }
       },
       "spi3_miso": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          },
+          "PortType": {
+            "value": "data",
+            "value_src": "default"
+          },
+          "PortType.PROP_SRC": {
+            "value": "false",
+            "value_src": "default"
+          }
+        }
       },
       "spi4_miso": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          },
+          "PortType": {
+            "value": "data",
+            "value_src": "default"
+          },
+          "PortType.PROP_SRC": {
+            "value": "false",
+            "value_src": "default"
+          }
+        }
       },
       "spi1_out": {
         "type": "data",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "spi2_out": {
         "type": "data",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "spi3_out": {
         "type": "data",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "spi4_out": {
         "type": "data",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "user_led_din": {
         "type": "data",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter_sts_a": {
         "direction": "IO",
@@ -2348,16 +2727,16 @@
                   }
                 },
                 "interface_nets": {
-                  "s00_couplers_to_auto_pc": {
-                    "interface_ports": [
-                      "S_AXI",
-                      "auto_pc/S_AXI"
-                    ]
-                  },
                   "auto_pc_to_s00_couplers": {
                     "interface_ports": [
                       "M_AXI",
                       "auto_pc/M_AXI"
+                    ]
+                  },
+                  "s00_couplers_to_auto_pc": {
+                    "interface_ports": [
+                      "S_AXI",
+                      "auto_pc/S_AXI"
                     ]
                   }
                 },
@@ -3350,6 +3729,18 @@
               }
             },
             "interface_nets": {
+              "tier2_xbar_0_to_m01_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_0/M01_AXI",
+                  "m01_couplers/S_AXI"
+                ]
+              },
+              "m02_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M02_AXI",
+                  "m02_couplers/M_AXI"
+                ]
+              },
               "xbar_to_i00_couplers": {
                 "interface_ports": [
                   "xbar/M00_AXI",
@@ -3380,40 +3771,40 @@
                   "i02_couplers/S_AXI"
                 ]
               },
-              "tier2_xbar_0_to_m05_couplers": {
+              "ps7_0_axi_periph_to_s00_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_0/M05_AXI",
-                  "m05_couplers/S_AXI"
+                  "S00_AXI",
+                  "s00_couplers/S_AXI"
                 ]
               },
-              "tier2_xbar_0_to_m04_couplers": {
+              "i02_couplers_to_tier2_xbar_2": {
                 "interface_ports": [
-                  "tier2_xbar_0/M04_AXI",
-                  "m04_couplers/S_AXI"
+                  "i02_couplers/M_AXI",
+                  "tier2_xbar_2/S00_AXI"
                 ]
               },
-              "m05_couplers_to_ps7_0_axi_periph": {
+              "s00_couplers_to_xbar": {
                 "interface_ports": [
-                  "M05_AXI",
-                  "m05_couplers/M_AXI"
+                  "s00_couplers/M_AXI",
+                  "xbar/S00_AXI"
                 ]
               },
-              "m04_couplers_to_ps7_0_axi_periph": {
+              "m00_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M04_AXI",
-                  "m04_couplers/M_AXI"
+                  "M00_AXI",
+                  "m00_couplers/M_AXI"
                 ]
               },
-              "tier2_xbar_0_to_m03_couplers": {
+              "tier2_xbar_0_to_m00_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_0/M03_AXI",
-                  "m03_couplers/S_AXI"
+                  "tier2_xbar_0/M00_AXI",
+                  "m00_couplers/S_AXI"
                 ]
               },
-              "m02_couplers_to_ps7_0_axi_periph": {
+              "m01_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M02_AXI",
-                  "m02_couplers/M_AXI"
+                  "M01_AXI",
+                  "m01_couplers/M_AXI"
                 ]
               },
               "tier2_xbar_0_to_m02_couplers": {
@@ -3428,94 +3819,82 @@
                   "m03_couplers/M_AXI"
                 ]
               },
-              "ps7_0_axi_periph_to_s00_couplers": {
+              "tier2_xbar_0_to_m03_couplers": {
                 "interface_ports": [
-                  "S00_AXI",
-                  "s00_couplers/S_AXI"
+                  "tier2_xbar_0/M03_AXI",
+                  "m03_couplers/S_AXI"
                 ]
               },
-              "i02_couplers_to_tier2_xbar_2": {
+              "m04_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "i02_couplers/M_AXI",
-                  "tier2_xbar_2/S00_AXI"
+                  "M04_AXI",
+                  "m04_couplers/M_AXI"
                 ]
               },
-              "m00_couplers_to_ps7_0_axi_periph": {
+              "tier2_xbar_0_to_m04_couplers": {
                 "interface_ports": [
-                  "M00_AXI",
-                  "m00_couplers/M_AXI"
+                  "tier2_xbar_0/M04_AXI",
+                  "m04_couplers/S_AXI"
                 ]
               },
-              "s00_couplers_to_xbar": {
+              "m05_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "s00_couplers/M_AXI",
-                  "xbar/S00_AXI"
+                  "M05_AXI",
+                  "m05_couplers/M_AXI"
                 ]
               },
-              "m01_couplers_to_ps7_0_axi_periph": {
+              "tier2_xbar_0_to_m05_couplers": {
                 "interface_ports": [
-                  "M01_AXI",
-                  "m01_couplers/M_AXI"
+                  "tier2_xbar_0/M05_AXI",
+                  "m05_couplers/S_AXI"
                 ]
               },
-              "tier2_xbar_0_to_m00_couplers": {
+              "m06_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "tier2_xbar_0/M00_AXI",
-                  "m00_couplers/S_AXI"
+                  "M06_AXI",
+                  "m06_couplers/M_AXI"
                 ]
               },
-              "tier2_xbar_0_to_m01_couplers": {
+              "m07_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "tier2_xbar_0/M01_AXI",
-                  "m01_couplers/S_AXI"
+                  "M07_AXI",
+                  "m07_couplers/M_AXI"
                 ]
               },
-              "m15_couplers_to_ps7_0_axi_periph": {
+              "tier2_xbar_0_to_m06_couplers": {
                 "interface_ports": [
-                  "M15_AXI",
-                  "m15_couplers/M_AXI"
+                  "tier2_xbar_0/M06_AXI",
+                  "m06_couplers/S_AXI"
                 ]
               },
-              "tier2_xbar_1_to_m15_couplers": {
+              "tier2_xbar_0_to_m07_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_1/M07_AXI",
-                  "m15_couplers/S_AXI"
+                  "tier2_xbar_0/M07_AXI",
+                  "m07_couplers/S_AXI"
                 ]
               },
-              "m17_couplers_to_ps7_0_axi_periph": {
+              "m08_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M17_AXI",
-                  "m17_couplers/M_AXI"
+                  "M08_AXI",
+                  "m08_couplers/M_AXI"
                 ]
               },
-              "m16_couplers_to_ps7_0_axi_periph": {
+              "tier2_xbar_1_to_m08_couplers": {
                 "interface_ports": [
-                  "M16_AXI",
-                  "m16_couplers/M_AXI"
+                  "tier2_xbar_1/M00_AXI",
+                  "m08_couplers/S_AXI"
                 ]
               },
-              "tier2_xbar_2_to_m16_couplers": {
+              "m09_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "tier2_xbar_2/M00_AXI",
-                  "m16_couplers/S_AXI"
+                  "M09_AXI",
+                  "m09_couplers/M_AXI"
                 ]
               },
-              "tier2_xbar_2_to_m17_couplers": {
+              "tier2_xbar_1_to_m09_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_2/M01_AXI",
-                  "m17_couplers/S_AXI"
-                ]
-              },
-              "m14_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M14_AXI",
-                  "m14_couplers/M_AXI"
-                ]
-              },
-              "tier2_xbar_1_to_m14_couplers": {
-                "interface_ports": [
-                  "tier2_xbar_1/M06_AXI",
-                  "m14_couplers/S_AXI"
+                  "tier2_xbar_1/M01_AXI",
+                  "m09_couplers/S_AXI"
                 ]
               },
               "m10_couplers_to_ps7_0_axi_periph": {
@@ -3524,16 +3903,16 @@
                   "m10_couplers/M_AXI"
                 ]
               },
-              "tier2_xbar_1_to_m10_couplers": {
-                "interface_ports": [
-                  "tier2_xbar_1/M02_AXI",
-                  "m10_couplers/S_AXI"
-                ]
-              },
               "m11_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
                   "M11_AXI",
                   "m11_couplers/M_AXI"
+                ]
+              },
+              "tier2_xbar_1_to_m10_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_1/M02_AXI",
+                  "m10_couplers/S_AXI"
                 ]
               },
               "tier2_xbar_1_to_m11_couplers": {
@@ -3560,58 +3939,58 @@
                   "m12_couplers/S_AXI"
                 ]
               },
+              "m14_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M14_AXI",
+                  "m14_couplers/M_AXI"
+                ]
+              },
               "tier2_xbar_1_to_m13_couplers": {
                 "interface_ports": [
                   "tier2_xbar_1/M05_AXI",
                   "m13_couplers/S_AXI"
                 ]
               },
-              "m06_couplers_to_ps7_0_axi_periph": {
+              "m15_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M06_AXI",
-                  "m06_couplers/M_AXI"
+                  "M15_AXI",
+                  "m15_couplers/M_AXI"
                 ]
               },
-              "tier2_xbar_0_to_m06_couplers": {
+              "tier2_xbar_1_to_m14_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_0/M06_AXI",
-                  "m06_couplers/S_AXI"
+                  "tier2_xbar_1/M06_AXI",
+                  "m14_couplers/S_AXI"
                 ]
               },
-              "m07_couplers_to_ps7_0_axi_periph": {
+              "tier2_xbar_1_to_m15_couplers": {
                 "interface_ports": [
-                  "M07_AXI",
-                  "m07_couplers/M_AXI"
+                  "tier2_xbar_1/M07_AXI",
+                  "m15_couplers/S_AXI"
                 ]
               },
-              "tier2_xbar_0_to_m07_couplers": {
+              "m16_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "tier2_xbar_0/M07_AXI",
-                  "m07_couplers/S_AXI"
+                  "M16_AXI",
+                  "m16_couplers/M_AXI"
                 ]
               },
-              "m08_couplers_to_ps7_0_axi_periph": {
+              "m17_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M08_AXI",
-                  "m08_couplers/M_AXI"
+                  "M17_AXI",
+                  "m17_couplers/M_AXI"
                 ]
               },
-              "m09_couplers_to_ps7_0_axi_periph": {
+              "tier2_xbar_2_to_m16_couplers": {
                 "interface_ports": [
-                  "M09_AXI",
-                  "m09_couplers/M_AXI"
+                  "tier2_xbar_2/M00_AXI",
+                  "m16_couplers/S_AXI"
                 ]
               },
-              "tier2_xbar_1_to_m08_couplers": {
+              "tier2_xbar_2_to_m17_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_1/M00_AXI",
-                  "m08_couplers/S_AXI"
-                ]
-              },
-              "tier2_xbar_1_to_m09_couplers": {
-                "interface_ports": [
-                  "tier2_xbar_1/M01_AXI",
-                  "m09_couplers/S_AXI"
+                  "tier2_xbar_2/M01_AXI",
+                  "m17_couplers/S_AXI"
                 ]
               }
             },
@@ -3928,28 +4307,28 @@
               "ps7_0_axi_periph/M15_AXI"
             ]
           },
-          "Conn1": {
-            "interface_ports": [
-              "M12_AXI",
-              "ps7_0_axi_periph/M12_AXI"
-            ]
-          },
           "ps7_0_axi_periph_M11_AXI": {
             "interface_ports": [
               "M11_AXI",
               "ps7_0_axi_periph/M11_AXI"
             ]
           },
-          "ps7_0_axi_periph_M02_AXI": {
+          "Conn1": {
             "interface_ports": [
-              "M02_AXI",
-              "ps7_0_axi_periph/M02_AXI"
+              "M12_AXI",
+              "ps7_0_axi_periph/M12_AXI"
             ]
           },
           "ps7_0_axi_periph_M05_AXI": {
             "interface_ports": [
               "M05_AXI",
               "ps7_0_axi_periph/M05_AXI"
+            ]
+          },
+          "ps7_0_axi_periph_M02_AXI": {
+            "interface_ports": [
+              "M02_AXI",
+              "ps7_0_axi_periph/M02_AXI"
             ]
           },
           "Conn2": {
@@ -4024,10 +4403,10 @@
               "ps7_0_axi_periph/M10_AXI"
             ]
           },
-          "processing_system7_0_FIXED_IO": {
+          "ps7_0_axi_periph_M06_AXI": {
             "interface_ports": [
-              "FIXED_IO",
-              "processing_system7_0/FIXED_IO"
+              "M06_AXI",
+              "ps7_0_axi_periph/M06_AXI"
             ]
           },
           "Conn4": {
@@ -4036,10 +4415,10 @@
               "ps7_0_axi_periph/M14_AXI"
             ]
           },
-          "ps7_0_axi_periph_M06_AXI": {
+          "processing_system7_0_FIXED_IO": {
             "interface_ports": [
-              "M06_AXI",
-              "ps7_0_axi_periph/M06_AXI"
+              "FIXED_IO",
+              "processing_system7_0/FIXED_IO"
             ]
           }
         },
@@ -4785,22 +5164,16 @@
       }
     },
     "interface_nets": {
-      "hier_ps_M17_AXI": {
+      "processing_system7_0_FIXED_IO": {
         "interface_ports": [
-          "amdc_gpio_direct_1/S00_AXI",
-          "hier_ps/M17_AXI"
+          "FIXED_IO",
+          "hier_ps/FIXED_IO"
         ]
       },
-      "ps7_0_axi_periph_M03_AXI": {
+      "processing_system7_0_DDR": {
         "interface_ports": [
-          "hier_ps/M03_AXI",
-          "control_timer_0/S_AXI"
-        ]
-      },
-      "ps7_0_axi_periph_M00_AXI": {
-        "interface_ports": [
-          "hier_ps/M00_AXI",
-          "amdc_adc_0/S00_AXI"
+          "DDR",
+          "hier_ps/DDR"
         ]
       },
       "ps7_0_axi_periph_M08_AXI": {
@@ -4809,10 +5182,34 @@
           "amdc_dac_0/S00_AXI"
         ]
       },
-      "ps7_0_axi_periph_M01_AXI": {
+      "ps7_0_axi_periph_M04_AXI": {
         "interface_ports": [
-          "hier_ps/M01_AXI",
-          "amdc_encoder_0/S00_AXI"
+          "hier_ps/M04_AXI",
+          "control_timer_1/S_AXI"
+        ]
+      },
+      "hier_ps_M07_AXI": {
+        "interface_ports": [
+          "hier_ps/M07_AXI",
+          "hier_powerstack/S00_AXI2"
+        ]
+      },
+      "ps7_0_axi_periph_M09_AXI": {
+        "interface_ports": [
+          "hier_ps/M09_AXI",
+          "amdc_gpio_mux_0/S00_AXI"
+        ]
+      },
+      "ps7_0_axi_periph_M03_AXI": {
+        "interface_ports": [
+          "hier_ps/M03_AXI",
+          "control_timer_0/S_AXI"
+        ]
+      },
+      "ps7_0_axi_periph_M10_AXI": {
+        "interface_ports": [
+          "hier_ps/M10_AXI",
+          "hier_amds/S00_AXI"
         ]
       },
       "ps7_0_axi_periph_M06_AXI": {
@@ -4821,28 +5218,22 @@
           "hier_powerstack/S00_AXI1"
         ]
       },
-      "S00_AXI1_1": {
+      "ps7_0_axi_periph_M00_AXI": {
         "interface_ports": [
-          "hier_ild1420_1/S00_AXI1",
-          "hier_ps/M15_AXI"
+          "hier_ps/M00_AXI",
+          "amdc_adc_0/S00_AXI"
         ]
       },
-      "ps7_0_axi_periph_M02_AXI": {
+      "hier_ps_M16_AXI": {
         "interface_ports": [
-          "hier_ps/M02_AXI",
-          "hier_powerstack/S00_AXI"
+          "amdc_gpio_direct_0/S00_AXI",
+          "hier_ps/M16_AXI"
         ]
       },
-      "ps7_0_axi_periph_M05_AXI": {
+      "S00_AXI_1": {
         "interface_ports": [
-          "hier_ps/M05_AXI",
-          "amdc_leds_0/S00_AXI"
-        ]
-      },
-      "ps7_0_axi_periph_M09_AXI": {
-        "interface_ports": [
-          "hier_ps/M09_AXI",
-          "amdc_gpio_mux_0/S00_AXI"
+          "hier_ild1420_1/S00_AXI",
+          "hier_ps/M14_AXI"
         ]
       },
       "hier_ps_M13_AXI": {
@@ -4857,52 +5248,40 @@
           "amdc_eddy_current_se_0/S00_AXI"
         ]
       },
-      "hier_ps_M16_AXI": {
+      "hier_ps_M17_AXI": {
         "interface_ports": [
-          "amdc_gpio_direct_0/S00_AXI",
-          "hier_ps/M16_AXI"
-        ]
-      },
-      "ps7_0_axi_periph_M04_AXI": {
-        "interface_ports": [
-          "hier_ps/M04_AXI",
-          "control_timer_1/S_AXI"
-        ]
-      },
-      "processing_system7_0_FIXED_IO": {
-        "interface_ports": [
-          "FIXED_IO",
-          "hier_ps/FIXED_IO"
-        ]
-      },
-      "S00_AXI_1": {
-        "interface_ports": [
-          "hier_ild1420_1/S00_AXI",
-          "hier_ps/M14_AXI"
-        ]
-      },
-      "processing_system7_0_DDR": {
-        "interface_ports": [
-          "DDR",
-          "hier_ps/DDR"
-        ]
-      },
-      "ps7_0_axi_periph_M10_AXI": {
-        "interface_ports": [
-          "hier_ps/M10_AXI",
-          "hier_amds/S00_AXI"
-        ]
-      },
-      "hier_ps_M07_AXI": {
-        "interface_ports": [
-          "hier_ps/M07_AXI",
-          "hier_powerstack/S00_AXI2"
+          "amdc_gpio_direct_1/S00_AXI",
+          "hier_ps/M17_AXI"
         ]
       },
       "hier_ps_M12_AXI": {
         "interface_ports": [
           "hier_ild1420_0/S00_AXI",
           "hier_ps/M12_AXI"
+        ]
+      },
+      "S00_AXI1_1": {
+        "interface_ports": [
+          "hier_ild1420_1/S00_AXI1",
+          "hier_ps/M15_AXI"
+        ]
+      },
+      "ps7_0_axi_periph_M01_AXI": {
+        "interface_ports": [
+          "hier_ps/M01_AXI",
+          "amdc_encoder_0/S00_AXI"
+        ]
+      },
+      "ps7_0_axi_periph_M05_AXI": {
+        "interface_ports": [
+          "hier_ps/M05_AXI",
+          "amdc_leds_0/S00_AXI"
+        ]
+      },
+      "ps7_0_axi_periph_M02_AXI": {
+        "interface_ports": [
+          "hier_ps/M02_AXI",
+          "hier_powerstack/S00_AXI"
         ]
       }
     },
@@ -5023,7 +5402,8 @@
           "hier_powerstack/carrier_low",
           "amdc_adc_0/pwm_carrier_low",
           "hier_amds/pwm_carrier_low",
-          "amdc_eddy_current_se_0/pwm_carrier_low"
+          "amdc_eddy_current_se_0/pwm_carrier_low",
+          "amdc_encoder_0/pwm_carrier_low"
         ]
       },
       "amdc_inverters_0_carrier_high": {
@@ -5031,7 +5411,8 @@
           "hier_powerstack/carrier_high",
           "amdc_adc_0/pwm_carrier_high",
           "hier_amds/pwm_carrier_high",
-          "amdc_eddy_current_se_0/pwm_carrier_high"
+          "amdc_eddy_current_se_0/pwm_carrier_high",
+          "amdc_encoder_0/pwm_carrier_high"
         ]
       },
       "xlconstant_4_dout": {

--- a/hw/amdc_reve.bd
+++ b/hw/amdc_reve.bd
@@ -5,11 +5,9 @@
       "device": "xc7z030sbg485-1",
       "name": "amdc_reve",
       "synth_flow_mode": "Hierarchical",
-      "tool_version": "2019.1",
-      "validated": "true"
+      "tool_version": "2019.1"
     },
     "design_tree": {
-      "amdc_encoder_0": "",
       "xlconstant_2": "",
       "xlconstant_4": "",
       "amdc_leds_0": "",
@@ -184,72 +182,17 @@
         "xlconstant_3": "",
         "xlslice_3": "",
         "amdc_eddy_current_se_0": ""
-      }
+      },
+      "amdc_encoder_0": ""
     },
     "interface_ports": {
       "DDR": {
         "mode": "Master",
-        "vlnv": "xilinx.com:interface:ddrx_rtl:1.0",
-        "parameters": {
-          "AXI_ARBITRATION_SCHEME": {
-            "value": "TDM",
-            "value_src": "default"
-          },
-          "BURST_LENGTH": {
-            "value": "8",
-            "value_src": "default"
-          },
-          "CAN_DEBUG": {
-            "value": "false",
-            "value_src": "default"
-          },
-          "CAS_LATENCY": {
-            "value": "11",
-            "value_src": "default"
-          },
-          "CAS_WRITE_LATENCY": {
-            "value": "11",
-            "value_src": "default"
-          },
-          "CS_ENABLED": {
-            "value": "true",
-            "value_src": "default"
-          },
-          "DATA_MASK_ENABLED": {
-            "value": "true",
-            "value_src": "default"
-          },
-          "DATA_WIDTH": {
-            "value": "8",
-            "value_src": "default"
-          },
-          "MEMORY_TYPE": {
-            "value": "COMPONENTS",
-            "value_src": "default"
-          },
-          "MEM_ADDR_MAP": {
-            "value": "ROW_COLUMN_BANK",
-            "value_src": "default"
-          },
-          "SLOT": {
-            "value": "Single",
-            "value_src": "default"
-          },
-          "TIMEPERIOD_PS": {
-            "value": "1250",
-            "value_src": "default"
-          }
-        }
+        "vlnv": "xilinx.com:interface:ddrx_rtl:1.0"
       },
       "FIXED_IO": {
         "mode": "Master",
-        "vlnv": "xilinx.com:display_processing_system7:fixedio_rtl:1.0",
-        "parameters": {
-          "CAN_DEBUG": {
-            "value": "false",
-            "value_src": "default"
-          }
-        }
+        "vlnv": "xilinx.com:display_processing_system7:fixedio_rtl:1.0"
       }
     },
     "ports": {
@@ -257,211 +200,97 @@
         "type": "data",
         "direction": "I",
         "left": "7",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "adc_clkout": {
         "type": "data",
-        "direction": "I",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "direction": "I"
       },
       "adc_sck": {
         "type": "data",
-        "direction": "O",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "direction": "O"
       },
       "adc_cnv": {
         "type": "data",
-        "direction": "O",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "direction": "O"
       },
       "encoder_1z": {
         "type": "data",
-        "direction": "I",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "direction": "I"
       },
       "encoder_2z": {
         "type": "data",
-        "direction": "I",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "direction": "I"
       },
       "encoder_2b": {
         "type": "data",
-        "direction": "I",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "direction": "I"
       },
       "encoder_2a": {
         "type": "data",
-        "direction": "I",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "direction": "I"
       },
       "encoder_1a": {
         "type": "data",
-        "direction": "I",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "direction": "I"
       },
       "encoder_1b": {
         "type": "data",
-        "direction": "I",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "direction": "I"
       },
       "inverter8_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "inverter7_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "inverter6_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "inverter5_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "inverter4_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "inverter3_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "inverter2_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "inverter1_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "user_led_din": {
         "type": "data",
         "direction": "O",
         "left": "0",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "inverter_sts_a": {
         "direction": "IO",
@@ -487,104 +316,52 @@
         "type": "data",
         "direction": "I",
         "left": "2",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "gpio2_in": {
         "type": "data",
         "direction": "I",
         "left": "2",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "gpio3_in": {
         "type": "data",
         "direction": "I",
         "left": "2",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "gpio4_in": {
         "type": "data",
         "direction": "I",
         "left": "2",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "gpio1_out": {
         "type": "data",
         "direction": "O",
         "left": "2",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "gpio2_out": {
         "type": "data",
         "direction": "O",
         "left": "2",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "gpio3_out": {
         "type": "data",
         "direction": "O",
         "left": "2",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       },
       "gpio4_out": {
         "type": "data",
         "direction": "O",
         "left": "2",
-        "right": "0",
-        "parameters": {
-          "LAYERED_METADATA": {
-            "value": "undef",
-            "value_src": "default"
-          }
-        }
+        "right": "0"
       }
     },
     "components": {
-      "amdc_encoder_0": {
-        "vlnv": "wisc.edu:user:amdc_encoder:1.0",
-        "xci_name": "amdc_reve_amdc_encoder_0_0"
-      },
       "xlconstant_2": {
         "vlnv": "xilinx.com:ip:xlconstant:1.1",
         "xci_name": "amdc_reve_xlconstant_2_0",
@@ -1761,7 +1538,7 @@
             "xci_name": "amdc_reve_ps7_0_axi_periph_0",
             "parameters": {
               "NUM_MI": {
-                "value": "33"
+                "value": "34"
               },
               "S00_HAS_DATA_FIFO": {
                 "value": "2"
@@ -2524,7 +2301,7 @@
                 "xci_name": "amdc_reve_tier2_xbar_3_0",
                 "parameters": {
                   "NUM_MI": {
-                    "value": "7"
+                    "value": "8"
                   },
                   "NUM_SI": {
                     "value": "1"
@@ -4707,58 +4484,10 @@
               }
             },
             "interface_nets": {
-              "tier2_xbar_3_to_m26_couplers": {
+              "tier2_xbar_2_to_m21_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_3/M02_AXI",
-                  "m26_couplers/S_AXI"
-                ]
-              },
-              "m27_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M27_AXI",
-                  "m27_couplers/M_AXI"
-                ]
-              },
-              "m28_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M28_AXI",
-                  "m28_couplers/M_AXI"
-                ]
-              },
-              "tier2_xbar_3_to_m27_couplers": {
-                "interface_ports": [
-                  "tier2_xbar_3/M03_AXI",
-                  "m27_couplers/S_AXI"
-                ]
-              },
-              "tier2_xbar_2_to_m18_couplers": {
-                "interface_ports": [
-                  "tier2_xbar_2/M02_AXI",
-                  "m18_couplers/S_AXI"
-                ]
-              },
-              "m19_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M19_AXI",
-                  "m19_couplers/M_AXI"
-                ]
-              },
-              "tier2_xbar_2_to_m19_couplers": {
-                "interface_ports": [
-                  "tier2_xbar_2/M03_AXI",
-                  "m19_couplers/S_AXI"
-                ]
-              },
-              "m20_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M20_AXI",
-                  "m20_couplers/M_AXI"
-                ]
-              },
-              "tier2_xbar_2_to_m20_couplers": {
-                "interface_ports": [
-                  "tier2_xbar_2/M04_AXI",
-                  "m20_couplers/S_AXI"
+                  "tier2_xbar_2/M05_AXI",
+                  "m21_couplers/S_AXI"
                 ]
               },
               "m21_couplers_to_ps7_0_axi_periph": {
@@ -4773,10 +4502,10 @@
                   "m22_couplers/M_AXI"
                 ]
               },
-              "tier2_xbar_2_to_m21_couplers": {
+              "tier2_xbar_2_to_m22_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_2/M05_AXI",
-                  "m21_couplers/S_AXI"
+                  "tier2_xbar_2/M06_AXI",
+                  "m22_couplers/S_AXI"
                 ]
               },
               "m23_couplers_to_ps7_0_axi_periph": {
@@ -4785,10 +4514,16 @@
                   "m23_couplers/M_AXI"
                 ]
               },
-              "tier2_xbar_2_to_m22_couplers": {
+              "tier2_xbar_2_to_m23_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_2/M06_AXI",
-                  "m22_couplers/S_AXI"
+                  "tier2_xbar_2/M07_AXI",
+                  "m23_couplers/S_AXI"
+                ]
+              },
+              "tier2_xbar_3_to_m24_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_3/M00_AXI",
+                  "m24_couplers/S_AXI"
                 ]
               },
               "m24_couplers_to_ps7_0_axi_periph": {
@@ -4797,22 +4532,10 @@
                   "m24_couplers/M_AXI"
                 ]
               },
-              "tier2_xbar_2_to_m23_couplers": {
-                "interface_ports": [
-                  "tier2_xbar_2/M07_AXI",
-                  "m23_couplers/S_AXI"
-                ]
-              },
               "m25_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
                   "M25_AXI",
                   "m25_couplers/M_AXI"
-                ]
-              },
-              "tier2_xbar_3_to_m24_couplers": {
-                "interface_ports": [
-                  "tier2_xbar_3/M00_AXI",
-                  "m24_couplers/S_AXI"
                 ]
               },
               "tier2_xbar_3_to_m25_couplers": {
@@ -4857,12 +4580,6 @@
                   "m00_couplers/S_AXI"
                 ]
               },
-              "m02_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M02_AXI",
-                  "m02_couplers/M_AXI"
-                ]
-              },
               "tier2_xbar_0_to_m01_couplers": {
                 "interface_ports": [
                   "tier2_xbar_0/M01_AXI",
@@ -4875,10 +4592,10 @@
                   "m02_couplers/S_AXI"
                 ]
               },
-              "m03_couplers_to_ps7_0_axi_periph": {
+              "m02_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M03_AXI",
-                  "m03_couplers/M_AXI"
+                  "M02_AXI",
+                  "m02_couplers/M_AXI"
                 ]
               },
               "m04_couplers_to_ps7_0_axi_periph": {
@@ -4893,10 +4610,10 @@
                   "m03_couplers/S_AXI"
                 ]
               },
-              "m05_couplers_to_ps7_0_axi_periph": {
+              "m03_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M05_AXI",
-                  "m05_couplers/M_AXI"
+                  "M03_AXI",
+                  "m03_couplers/M_AXI"
                 ]
               },
               "tier2_xbar_0_to_m04_couplers": {
@@ -4905,10 +4622,10 @@
                   "m04_couplers/S_AXI"
                 ]
               },
-              "m06_couplers_to_ps7_0_axi_periph": {
+              "m05_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M06_AXI",
-                  "m06_couplers/M_AXI"
+                  "M05_AXI",
+                  "m05_couplers/M_AXI"
                 ]
               },
               "tier2_xbar_0_to_m05_couplers": {
@@ -4923,10 +4640,10 @@
                   "m06_couplers/S_AXI"
                 ]
               },
-              "m07_couplers_to_ps7_0_axi_periph": {
+              "m06_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M07_AXI",
-                  "m07_couplers/M_AXI"
+                  "M06_AXI",
+                  "m06_couplers/M_AXI"
                 ]
               },
               "tier2_xbar_0_to_m07_couplers": {
@@ -4935,10 +4652,10 @@
                   "m07_couplers/S_AXI"
                 ]
               },
-              "m08_couplers_to_ps7_0_axi_periph": {
+              "m07_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M08_AXI",
-                  "m08_couplers/M_AXI"
+                  "M07_AXI",
+                  "m07_couplers/M_AXI"
                 ]
               },
               "tier2_xbar_1_to_m08_couplers": {
@@ -4947,10 +4664,10 @@
                   "m08_couplers/S_AXI"
                 ]
               },
-              "m09_couplers_to_ps7_0_axi_periph": {
+              "m08_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M09_AXI",
-                  "m09_couplers/M_AXI"
+                  "M08_AXI",
+                  "m08_couplers/M_AXI"
                 ]
               },
               "m10_couplers_to_ps7_0_axi_periph": {
@@ -4965,22 +4682,16 @@
                   "m09_couplers/S_AXI"
                 ]
               },
+              "m09_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M09_AXI",
+                  "m09_couplers/M_AXI"
+                ]
+              },
               "tier2_xbar_1_to_m10_couplers": {
                 "interface_ports": [
                   "tier2_xbar_1/M02_AXI",
                   "m10_couplers/S_AXI"
-                ]
-              },
-              "m11_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M11_AXI",
-                  "m11_couplers/M_AXI"
-                ]
-              },
-              "m12_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M12_AXI",
-                  "m12_couplers/M_AXI"
                 ]
               },
               "tier2_xbar_1_to_m11_couplers": {
@@ -4989,16 +4700,76 @@
                   "m11_couplers/S_AXI"
                 ]
               },
+              "m12_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M12_AXI",
+                  "m12_couplers/M_AXI"
+                ]
+              },
+              "m11_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M11_AXI",
+                  "m11_couplers/M_AXI"
+                ]
+              },
+              "tier2_xbar_3_to_m26_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_3/M02_AXI",
+                  "m26_couplers/S_AXI"
+                ]
+              },
+              "m27_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M27_AXI",
+                  "m27_couplers/M_AXI"
+                ]
+              },
+              "tier2_xbar_3_to_m27_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_3/M03_AXI",
+                  "m27_couplers/S_AXI"
+                ]
+              },
+              "m28_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M28_AXI",
+                  "m28_couplers/M_AXI"
+                ]
+              },
+              "tier2_xbar_2_to_m18_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_2/M02_AXI",
+                  "m18_couplers/S_AXI"
+                ]
+              },
+              "m19_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M19_AXI",
+                  "m19_couplers/M_AXI"
+                ]
+              },
+              "tier2_xbar_2_to_m19_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_2/M03_AXI",
+                  "m19_couplers/S_AXI"
+                ]
+              },
+              "m20_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M20_AXI",
+                  "m20_couplers/M_AXI"
+                ]
+              },
+              "tier2_xbar_2_to_m20_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_2/M04_AXI",
+                  "m20_couplers/S_AXI"
+                ]
+              },
               "tier2_xbar_1_to_m12_couplers": {
                 "interface_ports": [
                   "tier2_xbar_1/M04_AXI",
                   "m12_couplers/S_AXI"
-                ]
-              },
-              "m13_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M13_AXI",
-                  "m13_couplers/M_AXI"
                 ]
               },
               "tier2_xbar_1_to_m13_couplers": {
@@ -5007,10 +4778,10 @@
                   "m13_couplers/S_AXI"
                 ]
               },
-              "m14_couplers_to_ps7_0_axi_periph": {
+              "m13_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M14_AXI",
-                  "m14_couplers/M_AXI"
+                  "M13_AXI",
+                  "m13_couplers/M_AXI"
                 ]
               },
               "tier2_xbar_1_to_m14_couplers": {
@@ -5019,16 +4790,16 @@
                   "m14_couplers/S_AXI"
                 ]
               },
-              "m15_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M15_AXI",
-                  "m15_couplers/M_AXI"
-                ]
-              },
               "m16_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
                   "M16_AXI",
                   "m16_couplers/M_AXI"
+                ]
+              },
+              "m14_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M14_AXI",
+                  "m14_couplers/M_AXI"
                 ]
               },
               "tier2_xbar_1_to_m15_couplers": {
@@ -5041,6 +4812,12 @@
                 "interface_ports": [
                   "tier2_xbar_2/M00_AXI",
                   "m16_couplers/S_AXI"
+                ]
+              },
+              "m15_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M15_AXI",
+                  "m15_couplers/M_AXI"
                 ]
               },
               "m17_couplers_to_ps7_0_axi_periph": {
@@ -5061,28 +4838,28 @@
                   "m18_couplers/M_AXI"
                 ]
               },
-              "m31_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M31_AXI",
-                  "m31_couplers/M_AXI"
-                ]
-              },
               "tier2_xbar_3_to_m30_couplers": {
                 "interface_ports": [
                   "tier2_xbar_3/M06_AXI",
                   "m30_couplers/S_AXI"
                 ]
               },
-              "m32_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M32_AXI",
-                  "m32_couplers/M_AXI"
-                ]
-              },
               "tier2_xbar_4_to_m31_couplers": {
                 "interface_ports": [
                   "tier2_xbar_4/M00_AXI",
                   "m31_couplers/S_AXI"
+                ]
+              },
+              "m31_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M31_AXI",
+                  "m31_couplers/M_AXI"
+                ]
+              },
+              "m32_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M32_AXI",
+                  "m32_couplers/M_AXI"
                 ]
               },
               "tier2_xbar_4_to_m32_couplers": {
@@ -5097,16 +4874,16 @@
                   "m28_couplers/S_AXI"
                 ]
               },
-              "m29_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M29_AXI",
-                  "m29_couplers/M_AXI"
-                ]
-              },
               "m30_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
                   "M30_AXI",
                   "m30_couplers/M_AXI"
+                ]
+              },
+              "m29_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M29_AXI",
+                  "m29_couplers/M_AXI"
                 ]
               },
               "tier2_xbar_3_to_m29_couplers": {
@@ -5145,16 +4922,16 @@
                   "tier2_xbar_1/S00_AXI"
                 ]
               },
-              "i02_couplers_to_tier2_xbar_2": {
-                "interface_ports": [
-                  "i02_couplers/M_AXI",
-                  "tier2_xbar_2/S00_AXI"
-                ]
-              },
               "xbar_to_i03_couplers": {
                 "interface_ports": [
                   "xbar/M03_AXI",
                   "i03_couplers/S_AXI"
+                ]
+              },
+              "i02_couplers_to_tier2_xbar_2": {
+                "interface_ports": [
+                  "i02_couplers/M_AXI",
+                  "tier2_xbar_2/S00_AXI"
                 ]
               },
               "xbar_to_i04_couplers": {
@@ -5163,16 +4940,16 @@
                   "i04_couplers/S_AXI"
                 ]
               },
-              "i03_couplers_to_tier2_xbar_3": {
-                "interface_ports": [
-                  "i03_couplers/M_AXI",
-                  "tier2_xbar_3/S00_AXI"
-                ]
-              },
               "i04_couplers_to_tier2_xbar_4": {
                 "interface_ports": [
                   "i04_couplers/M_AXI",
                   "tier2_xbar_4/S00_AXI"
+                ]
+              },
+              "i03_couplers_to_tier2_xbar_3": {
+                "interface_ports": [
+                  "i03_couplers/M_AXI",
+                  "tier2_xbar_3/S00_AXI"
                 ]
               }
             },
@@ -5699,34 +5476,10 @@
           }
         },
         "interface_nets": {
-          "Conn26": {
-            "interface_ports": [
-              "M26_AXI",
-              "ps7_0_axi_periph/M26_AXI"
-            ]
-          },
-          "Conn10": {
-            "interface_ports": [
-              "M09_AXI",
-              "ps7_0_axi_periph/M09_AXI"
-            ]
-          },
-          "Conn25": {
-            "interface_ports": [
-              "M25_AXI",
-              "ps7_0_axi_periph/M25_AXI"
-            ]
-          },
           "Conn28": {
             "interface_ports": [
               "M28_AXI",
               "ps7_0_axi_periph/M28_AXI"
-            ]
-          },
-          "processing_system7_0_FIXED_IO": {
-            "interface_ports": [
-              "FIXED_IO",
-              "processing_system7_0/FIXED_IO"
             ]
           },
           "Conn12": {
@@ -5735,16 +5488,10 @@
               "ps7_0_axi_periph/M11_AXI"
             ]
           },
-          "Conn14": {
+          "processing_system7_0_FIXED_IO": {
             "interface_ports": [
-              "M14_AXI",
-              "ps7_0_axi_periph/M14_AXI"
-            ]
-          },
-          "Conn22": {
-            "interface_ports": [
-              "M22_AXI",
-              "ps7_0_axi_periph/M22_AXI"
+              "FIXED_IO",
+              "processing_system7_0/FIXED_IO"
             ]
           },
           "Conn1": {
@@ -5771,16 +5518,16 @@
               "ps7_0_axi_periph/M18_AXI"
             ]
           },
-          "ps7_0_axi_periph_M29_AXI": {
-            "interface_ports": [
-              "M29_AXI",
-              "ps7_0_axi_periph/M29_AXI"
-            ]
-          },
           "Conn2": {
             "interface_ports": [
               "M01_AXI",
               "ps7_0_axi_periph/M01_AXI"
+            ]
+          },
+          "ps7_0_axi_periph_M29_AXI": {
+            "interface_ports": [
+              "M29_AXI",
+              "ps7_0_axi_periph/M29_AXI"
             ]
           },
           "Conn9": {
@@ -5801,16 +5548,16 @@
               "ps7_0_axi_periph/M16_AXI"
             ]
           },
-          "ps7_0_axi_periph_M31_AXI": {
-            "interface_ports": [
-              "M31_AXI",
-              "ps7_0_axi_periph/M31_AXI"
-            ]
-          },
           "Conn13": {
             "interface_ports": [
               "M12_AXI",
               "ps7_0_axi_periph/M12_AXI"
+            ]
+          },
+          "ps7_0_axi_periph_M31_AXI": {
+            "interface_ports": [
+              "M31_AXI",
+              "ps7_0_axi_periph/M31_AXI"
             ]
           },
           "Conn7": {
@@ -5819,16 +5566,16 @@
               "ps7_0_axi_periph/M06_AXI"
             ]
           },
-          "Conn19": {
-            "interface_ports": [
-              "M19_AXI",
-              "ps7_0_axi_periph/M19_AXI"
-            ]
-          },
           "Conn15": {
             "interface_ports": [
               "M15_AXI",
               "ps7_0_axi_periph/M15_AXI"
+            ]
+          },
+          "Conn19": {
+            "interface_ports": [
+              "M19_AXI",
+              "ps7_0_axi_periph/M19_AXI"
             ]
           },
           "Conn6": {
@@ -5849,16 +5596,16 @@
               "ps7_0_axi_periph/M17_AXI"
             ]
           },
-          "processing_system7_0_DDR": {
-            "interface_ports": [
-              "DDR",
-              "processing_system7_0/DDR"
-            ]
-          },
           "Conn11": {
             "interface_ports": [
               "M10_AXI",
               "ps7_0_axi_periph/M10_AXI"
+            ]
+          },
+          "processing_system7_0_DDR": {
+            "interface_ports": [
+              "DDR",
+              "processing_system7_0/DDR"
             ]
           },
           "Conn8": {
@@ -5873,10 +5620,10 @@
               "ps7_0_axi_periph/M32_AXI"
             ]
           },
-          "processing_system7_0_M_AXI_GP0": {
+          "Conn5": {
             "interface_ports": [
-              "processing_system7_0/M_AXI_GP0",
-              "ps7_0_axi_periph/S00_AXI"
+              "M04_AXI",
+              "ps7_0_axi_periph/M04_AXI"
             ]
           },
           "Conn20": {
@@ -5885,22 +5632,16 @@
               "ps7_0_axi_periph/M20_AXI"
             ]
           },
-          "Conn5": {
-            "interface_ports": [
-              "M04_AXI",
-              "ps7_0_axi_periph/M04_AXI"
-            ]
-          },
           "Conn24": {
             "interface_ports": [
               "M24_AXI",
               "ps7_0_axi_periph/M24_AXI"
             ]
           },
-          "ps7_0_axi_periph_M13_AXI": {
+          "processing_system7_0_M_AXI_GP0": {
             "interface_ports": [
-              "M13_AXI",
-              "ps7_0_axi_periph/M13_AXI"
+              "processing_system7_0/M_AXI_GP0",
+              "ps7_0_axi_periph/S00_AXI"
             ]
           },
           "Conn23": {
@@ -5909,10 +5650,46 @@
               "ps7_0_axi_periph/M23_AXI"
             ]
           },
+          "ps7_0_axi_periph_M13_AXI": {
+            "interface_ports": [
+              "M13_AXI",
+              "ps7_0_axi_periph/M13_AXI"
+            ]
+          },
           "Conn4": {
             "interface_ports": [
               "M03_AXI",
               "ps7_0_axi_periph/M03_AXI"
+            ]
+          },
+          "Conn14": {
+            "interface_ports": [
+              "M14_AXI",
+              "ps7_0_axi_periph/M14_AXI"
+            ]
+          },
+          "Conn22": {
+            "interface_ports": [
+              "M22_AXI",
+              "ps7_0_axi_periph/M22_AXI"
+            ]
+          },
+          "Conn10": {
+            "interface_ports": [
+              "M09_AXI",
+              "ps7_0_axi_periph/M09_AXI"
+            ]
+          },
+          "Conn26": {
+            "interface_ports": [
+              "M26_AXI",
+              "ps7_0_axi_periph/M26_AXI"
+            ]
+          },
+          "Conn25": {
+            "interface_ports": [
+              "M25_AXI",
+              "ps7_0_axi_periph/M25_AXI"
             ]
           }
         },
@@ -6631,16 +6408,16 @@
               }
             },
             "interface_nets": {
-              "hier_ps_M13_AXI": {
-                "interface_ports": [
-                  "S00_AXI1",
-                  "amdc_ild1420_1/S00_AXI"
-                ]
-              },
               "hier_ps_M12_AXI": {
                 "interface_ports": [
                   "S00_AXI",
                   "amdc_ild1420_0/S00_AXI"
+                ]
+              },
+              "hier_ps_M13_AXI": {
+                "interface_ports": [
+                  "S00_AXI1",
+                  "amdc_ild1420_1/S00_AXI"
                 ]
               }
             },
@@ -6789,11 +6566,11 @@
           },
           "xlconstant_3": {
             "vlnv": "xilinx.com:ip:xlconstant:1.1",
-            "xci_name": "amdc_reve_xlconstant_0_5"
+            "xci_name": "amdc_reve_xlconstant_3_5"
           },
           "xlslice_3": {
             "vlnv": "xilinx.com:ip:xlslice:1.0",
-            "xci_name": "amdc_reve_xlslice_0_13",
+            "xci_name": "amdc_reve_xlslice_3_4",
             "parameters": {
               "DIN_FROM": {
                 "value": "0"
@@ -6812,16 +6589,22 @@
           }
         },
         "interface_nets": {
-          "S00_AXI3_1": {
-            "interface_ports": [
-              "S00_AXI3",
-              "hier_ild1420_0/S00_AXI"
-            ]
-          },
           "S00_AXI1_1": {
             "interface_ports": [
               "S00_AXI1",
               "amdc_eddy_current_se_0/S00_AXI"
+            ]
+          },
+          "S00_AXI5_1": {
+            "interface_ports": [
+              "S00_AXI5",
+              "amdc_gpio_direct_0/S00_AXI"
+            ]
+          },
+          "S00_AXI3_1": {
+            "interface_ports": [
+              "S00_AXI3",
+              "hier_ild1420_0/S00_AXI"
             ]
           },
           "S00_AXI2_1": {
@@ -6840,12 +6623,6 @@
             "interface_ports": [
               "S00_AXI",
               "amdc_gp3io_mux_0/S00_AXI"
-            ]
-          },
-          "S00_AXI5_1": {
-            "interface_ports": [
-              "S00_AXI5",
-              "amdc_gpio_direct_0/S00_AXI"
             ]
           }
         },
@@ -7060,16 +6837,16 @@
           }
         },
         "interface_nets": {
-          "hier_ps_M32_AXI": {
-            "interface_ports": [
-              "S_AXI",
-              "control_timer_0/S_AXI"
-            ]
-          },
           "hier_ps_M33_AXI": {
             "interface_ports": [
               "S_AXI1",
               "control_timer_1/S_AXI"
+            ]
+          },
+          "hier_ps_M32_AXI": {
+            "interface_ports": [
+              "S_AXI",
+              "control_timer_0/S_AXI"
             ]
           }
         },
@@ -7548,11 +7325,11 @@
           },
           "xlconstant_3": {
             "vlnv": "xilinx.com:ip:xlconstant:1.1",
-            "xci_name": "amdc_reve_xlconstant_0_4"
+            "xci_name": "amdc_reve_xlconstant_3_6"
           },
           "xlslice_3": {
             "vlnv": "xilinx.com:ip:xlslice:1.0",
-            "xci_name": "amdc_reve_xlslice_0_12",
+            "xci_name": "amdc_reve_xlslice_3_5",
             "parameters": {
               "DIN_FROM": {
                 "value": "0"
@@ -7577,12 +7354,6 @@
               "amdc_gpio_direct_0/S00_AXI"
             ]
           },
-          "S00_AXI2_1": {
-            "interface_ports": [
-              "S00_AXI2",
-              "hier_amds_0/S00_AXI"
-            ]
-          },
           "hier_ps_M48_AXI": {
             "interface_ports": [
               "S00_AXI",
@@ -7605,6 +7376,12 @@
             "interface_ports": [
               "S00_AXI4",
               "hier_ild1420_0/S00_AXI1"
+            ]
+          },
+          "S00_AXI2_1": {
+            "interface_ports": [
+              "S00_AXI2",
+              "hier_amds_0/S00_AXI"
             ]
           }
         },
@@ -8196,11 +7973,11 @@
           },
           "xlconstant_3": {
             "vlnv": "xilinx.com:ip:xlconstant:1.1",
-            "xci_name": "amdc_reve_xlconstant_0_6"
+            "xci_name": "amdc_reve_xlconstant_3_7"
           },
           "xlslice_3": {
             "vlnv": "xilinx.com:ip:xlslice:1.0",
-            "xci_name": "amdc_reve_xlslice_0_14",
+            "xci_name": "amdc_reve_xlslice_3_6",
             "parameters": {
               "DIN_FROM": {
                 "value": "0"
@@ -8237,10 +8014,10 @@
               "hier_ild1420_0/S00_AXI"
             ]
           },
-          "S00_AXI5_1": {
+          "hier_ps_M48_AXI": {
             "interface_ports": [
-              "S00_AXI5",
-              "amdc_gpio_direct_0/S00_AXI"
+              "S00_AXI",
+              "amdc_gp3io_mux_0/S00_AXI"
             ]
           },
           "S00_AXI1_1": {
@@ -8249,10 +8026,10 @@
               "amdc_eddy_current_se_0/S00_AXI"
             ]
           },
-          "hier_ps_M48_AXI": {
+          "S00_AXI5_1": {
             "interface_ports": [
-              "S00_AXI",
-              "amdc_gp3io_mux_0/S00_AXI"
+              "S00_AXI5",
+              "amdc_gpio_direct_0/S00_AXI"
             ]
           }
         },
@@ -8844,11 +8621,11 @@
           },
           "xlconstant_3": {
             "vlnv": "xilinx.com:ip:xlconstant:1.1",
-            "xci_name": "amdc_reve_xlconstant_0_7"
+            "xci_name": "amdc_reve_xlconstant_3_8"
           },
           "xlslice_3": {
             "vlnv": "xilinx.com:ip:xlslice:1.0",
-            "xci_name": "amdc_reve_xlslice_0_15",
+            "xci_name": "amdc_reve_xlslice_3_7",
             "parameters": {
               "DIN_FROM": {
                 "value": "0"
@@ -8885,16 +8662,16 @@
               "amdc_gp3io_mux_0/S00_AXI"
             ]
           },
-          "S00_AXI2_1": {
-            "interface_ports": [
-              "S00_AXI2",
-              "hier_amds_0/S00_AXI"
-            ]
-          },
           "S00_AXI5_1": {
             "interface_ports": [
               "S00_AXI5",
               "amdc_gpio_direct_0/S00_AXI"
+            ]
+          },
+          "S00_AXI2_1": {
+            "interface_ports": [
+              "S00_AXI2",
+              "hier_amds_0/S00_AXI"
             ]
           },
           "S00_AXI3_1": {
@@ -9058,43 +8835,17 @@
             ]
           }
         }
+      },
+      "amdc_encoder_0": {
+        "vlnv": "wisc.edu:user:amdc_encoder:1.0",
+        "xci_name": "amdc_reve_amdc_encoder_0_0"
       }
     },
     "interface_nets": {
-      "S00_AXI_5": {
+      "S00_AXI_2": {
         "interface_ports": [
-          "hier_gpio_3/S00_AXI",
-          "hier_ps/M24_AXI"
-        ]
-      },
-      "hier_ps_M29_AXI": {
-        "interface_ports": [
-          "hier_ps/M29_AXI",
-          "hier_gpio_0/S00_AXI5"
-        ]
-      },
-      "S00_AXI_3": {
-        "interface_ports": [
-          "hier_gpio_1/S00_AXI",
-          "hier_ps/M14_AXI"
-        ]
-      },
-      "hier_ps_M32_AXI1": {
-        "interface_ports": [
-          "hier_ps/M32_AXI",
-          "hier_gpio_3/S00_AXI5"
-        ]
-      },
-      "S00_AXI1_5": {
-        "interface_ports": [
-          "hier_gpio_3/S00_AXI1",
-          "hier_ps/M26_AXI"
-        ]
-      },
-      "hier_ps_M32_AXI": {
-        "interface_ports": [
-          "hier_timers/S_AXI",
-          "hier_ps/M00_AXI"
+          "hier_gpio_0/S00_AXI",
+          "hier_ps/M09_AXI"
         ]
       },
       "hier_ps_M36_AXI": {
@@ -9103,16 +8854,16 @@
           "hier_ps/M04_AXI"
         ]
       },
-      "hier_ps_M34_AXI": {
+      "S00_AXI_3": {
         "interface_ports": [
-          "amdc_encoder_0/S00_AXI",
-          "hier_ps/M02_AXI"
+          "hier_gpio_1/S00_AXI",
+          "hier_ps/M14_AXI"
         ]
       },
-      "S00_AXI4_4": {
+      "processing_system7_0_DDR": {
         "interface_ports": [
-          "hier_gpio_3/S00_AXI4",
-          "hier_ps/M28_AXI"
+          "DDR",
+          "hier_ps/DDR"
         ]
       },
       "S00_AXI4_1": {
@@ -9127,28 +8878,16 @@
           "hier_ps/M08_AXI"
         ]
       },
-      "S00_AXI_4": {
-        "interface_ports": [
-          "hier_gpio_2/S00_AXI",
-          "hier_ps/M19_AXI"
-        ]
-      },
-      "hier_ps_M30_AXI": {
-        "interface_ports": [
-          "hier_ps/M30_AXI",
-          "hier_gpio_1/S00_AXI5"
-        ]
-      },
-      "S00_AXI3_3": {
-        "interface_ports": [
-          "hier_gpio_2/S00_AXI3",
-          "hier_ps/M22_AXI"
-        ]
-      },
       "S00_AXI1_3": {
         "interface_ports": [
           "hier_gpio_1/S00_AXI1",
           "hier_ps/M16_AXI"
+        ]
+      },
+      "S00_AXI_5": {
+        "interface_ports": [
+          "hier_gpio_3/S00_AXI",
+          "hier_ps/M24_AXI"
         ]
       },
       "S00_AXI3_2": {
@@ -9157,46 +8896,46 @@
           "hier_ps/M17_AXI"
         ]
       },
-      "S00_AXI_2": {
+      "hier_ps_M29_AXI": {
         "interface_ports": [
-          "hier_gpio_0/S00_AXI",
-          "hier_ps/M09_AXI"
+          "hier_ps/M29_AXI",
+          "hier_gpio_0/S00_AXI5"
         ]
       },
-      "processing_system7_0_DDR": {
+      "hier_ps_M34_AXI": {
         "interface_ports": [
-          "DDR",
-          "hier_ps/DDR"
+          "amdc_encoder_0/S00_AXI",
+          "hier_ps/M02_AXI"
         ]
       },
-      "S00_AXI4_2": {
+      "S00_AXI4_4": {
         "interface_ports": [
-          "hier_gpio_1/S00_AXI4",
-          "hier_ps/M18_AXI"
+          "hier_gpio_3/S00_AXI4",
+          "hier_ps/M28_AXI"
         ]
       },
-      "S00_AXI1_4": {
+      "hier_ps_M30_AXI": {
         "interface_ports": [
-          "hier_gpio_2/S00_AXI1",
-          "hier_ps/M21_AXI"
+          "hier_ps/M30_AXI",
+          "hier_gpio_1/S00_AXI5"
         ]
       },
-      "processing_system7_0_FIXED_IO": {
+      "hier_ps_M32_AXI1": {
         "interface_ports": [
-          "FIXED_IO",
-          "hier_ps/FIXED_IO"
+          "hier_ps/M32_AXI",
+          "hier_gpio_3/S00_AXI5"
         ]
       },
-      "S00_AXI3_1": {
+      "hier_ps_M32_AXI": {
         "interface_ports": [
-          "hier_gpio_0/S00_AXI3",
-          "hier_ps/M12_AXI"
+          "hier_timers/S_AXI",
+          "hier_ps/M00_AXI"
         ]
       },
-      "S00_AXI1_2": {
+      "S00_AXI1_5": {
         "interface_ports": [
-          "hier_gpio_0/S00_AXI1",
-          "hier_ps/M11_AXI"
+          "hier_gpio_3/S00_AXI1",
+          "hier_ps/M26_AXI"
         ]
       },
       "S00_AXI3_4": {
@@ -9205,16 +8944,10 @@
           "hier_ps/M27_AXI"
         ]
       },
-      "S00_AXI1_1": {
+      "S00_AXI4_3": {
         "interface_ports": [
-          "hier_powerstack/S00_AXI1",
-          "hier_ps/M07_AXI"
-        ]
-      },
-      "hier_ps_M35_AXI": {
-        "interface_ports": [
-          "amdc_leds_0/S00_AXI",
-          "hier_ps/M03_AXI"
+          "hier_gpio_2/S00_AXI4",
+          "hier_ps/M23_AXI"
         ]
       },
       "S00_AXI2_2": {
@@ -9223,40 +8956,10 @@
           "hier_ps/M10_AXI"
         ]
       },
-      "S00_AXI2_3": {
+      "S00_AXI3_1": {
         "interface_ports": [
-          "hier_gpio_1/S00_AXI2",
-          "hier_ps/M15_AXI"
-        ]
-      },
-      "hier_ps_M33_AXI": {
-        "interface_ports": [
-          "hier_timers/S_AXI1",
-          "hier_ps/M01_AXI"
-        ]
-      },
-      "S00_AXI2_5": {
-        "interface_ports": [
-          "hier_gpio_3/S00_AXI2",
-          "hier_ps/M25_AXI"
-        ]
-      },
-      "S00_AXI2_4": {
-        "interface_ports": [
-          "hier_gpio_2/S00_AXI2",
-          "hier_ps/M20_AXI"
-        ]
-      },
-      "hier_ps_M37_AXI": {
-        "interface_ports": [
-          "amdc_dac_0/S00_AXI",
-          "hier_ps/M05_AXI"
-        ]
-      },
-      "S00_AXI4_3": {
-        "interface_ports": [
-          "hier_gpio_2/S00_AXI4",
-          "hier_ps/M23_AXI"
+          "hier_gpio_0/S00_AXI3",
+          "hier_ps/M12_AXI"
         ]
       },
       "S00_AXI_1": {
@@ -9265,10 +8968,88 @@
           "hier_ps/M06_AXI"
         ]
       },
+      "S00_AXI1_4": {
+        "interface_ports": [
+          "hier_gpio_2/S00_AXI1",
+          "hier_ps/M21_AXI"
+        ]
+      },
+      "S00_AXI2_3": {
+        "interface_ports": [
+          "hier_gpio_1/S00_AXI2",
+          "hier_ps/M15_AXI"
+        ]
+      },
+      "S00_AXI3_3": {
+        "interface_ports": [
+          "hier_gpio_2/S00_AXI3",
+          "hier_ps/M22_AXI"
+        ]
+      },
+      "S00_AXI2_5": {
+        "interface_ports": [
+          "hier_gpio_3/S00_AXI2",
+          "hier_ps/M25_AXI"
+        ]
+      },
+      "S00_AXI_4": {
+        "interface_ports": [
+          "hier_gpio_2/S00_AXI",
+          "hier_ps/M19_AXI"
+        ]
+      },
+      "processing_system7_0_FIXED_IO": {
+        "interface_ports": [
+          "FIXED_IO",
+          "hier_ps/FIXED_IO"
+        ]
+      },
+      "S00_AXI2_4": {
+        "interface_ports": [
+          "hier_gpio_2/S00_AXI2",
+          "hier_ps/M20_AXI"
+        ]
+      },
+      "S00_AXI4_2": {
+        "interface_ports": [
+          "hier_gpio_1/S00_AXI4",
+          "hier_ps/M18_AXI"
+        ]
+      },
+      "hier_ps_M35_AXI": {
+        "interface_ports": [
+          "amdc_leds_0/S00_AXI",
+          "hier_ps/M03_AXI"
+        ]
+      },
+      "S00_AXI1_1": {
+        "interface_ports": [
+          "hier_powerstack/S00_AXI1",
+          "hier_ps/M07_AXI"
+        ]
+      },
+      "hier_ps_M37_AXI": {
+        "interface_ports": [
+          "amdc_dac_0/S00_AXI",
+          "hier_ps/M05_AXI"
+        ]
+      },
+      "S00_AXI1_2": {
+        "interface_ports": [
+          "hier_gpio_0/S00_AXI1",
+          "hier_ps/M11_AXI"
+        ]
+      },
       "hier_ps_M31_AXI": {
         "interface_ports": [
           "hier_ps/M31_AXI",
           "hier_gpio_2/S00_AXI5"
+        ]
+      },
+      "hier_ps_M33_AXI": {
+        "interface_ports": [
+          "hier_timers/S_AXI1",
+          "hier_ps/M01_AXI"
         ]
       }
     },
@@ -9276,7 +9057,6 @@
       "processing_system7_0_FCLK_CLK0": {
         "ports": [
           "hier_ps/FCLK_CLK0",
-          "amdc_encoder_0/s00_axi_aclk",
           "amdc_leds_0/s00_axi_aclk",
           "amdc_adc_0/s00_axi_aclk",
           "amdc_dac_0/s00_axi_aclk",
@@ -9285,13 +9065,13 @@
           "hier_timers/s_axi_aclk",
           "hier_gpio_1/s00_axi_aclk",
           "hier_gpio_2/s00_axi_aclk",
-          "hier_gpio_3/s00_axi_aclk"
+          "hier_gpio_3/s00_axi_aclk",
+          "amdc_encoder_0/s00_axi_aclk"
         ]
       },
       "rst_ps7_0_100M_peripheral_aresetn": {
         "ports": [
           "hier_ps/S00_ARESETN",
-          "amdc_encoder_0/s00_axi_aresetn",
           "amdc_leds_0/s00_axi_aresetn",
           "amdc_adc_0/s00_axi_aresetn",
           "amdc_dac_0/s00_axi_aresetn",
@@ -9300,7 +9080,8 @@
           "hier_timers/s_axi_aresetn",
           "hier_gpio_1/s00_axi_aresetn",
           "hier_gpio_2/s00_axi_aresetn",
-          "hier_gpio_3/s00_axi_aresetn"
+          "hier_gpio_3/s00_axi_aresetn",
+          "amdc_encoder_0/s00_axi_aresetn"
         ]
       },
       "adc1_sdo_1": {
@@ -9358,7 +9139,8 @@
           "hier_gpio_0/pwm_carrier_low",
           "hier_gpio_1/pwm_carrier_low",
           "hier_gpio_2/pwm_carrier_low",
-          "hier_gpio_3/pwm_carrier_low"
+          "hier_gpio_3/pwm_carrier_low",
+          "amdc_encoder_0/pwm_carrier_low"
         ]
       },
       "amdc_inverters_0_carrier_high": {
@@ -9368,7 +9150,8 @@
           "hier_gpio_0/pwm_carrier_high",
           "hier_gpio_1/pwm_carrier_high",
           "hier_gpio_2/pwm_carrier_high",
-          "hier_gpio_3/pwm_carrier_high"
+          "hier_gpio_3/pwm_carrier_high",
+          "amdc_encoder_0/pwm_carrier_high"
         ]
       },
       "xlconstant_4_dout": {

--- a/hw/amdc_reve.bd
+++ b/hw/amdc_reve.bd
@@ -5,9 +5,11 @@
       "device": "xc7z030sbg485-1",
       "name": "amdc_reve",
       "synth_flow_mode": "Hierarchical",
-      "tool_version": "2019.1"
+      "tool_version": "2019.1",
+      "validated": "true"
     },
     "design_tree": {
+      "amdc_encoder_0": "",
       "xlconstant_2": "",
       "xlconstant_4": "",
       "amdc_leds_0": "",
@@ -182,17 +184,72 @@
         "xlconstant_3": "",
         "xlslice_3": "",
         "amdc_eddy_current_se_0": ""
-      },
-      "amdc_encoder_0": ""
+      }
     },
     "interface_ports": {
       "DDR": {
         "mode": "Master",
-        "vlnv": "xilinx.com:interface:ddrx_rtl:1.0"
+        "vlnv": "xilinx.com:interface:ddrx_rtl:1.0",
+        "parameters": {
+          "AXI_ARBITRATION_SCHEME": {
+            "value": "TDM",
+            "value_src": "default"
+          },
+          "BURST_LENGTH": {
+            "value": "8",
+            "value_src": "default"
+          },
+          "CAN_DEBUG": {
+            "value": "false",
+            "value_src": "default"
+          },
+          "CAS_LATENCY": {
+            "value": "11",
+            "value_src": "default"
+          },
+          "CAS_WRITE_LATENCY": {
+            "value": "11",
+            "value_src": "default"
+          },
+          "CS_ENABLED": {
+            "value": "true",
+            "value_src": "default"
+          },
+          "DATA_MASK_ENABLED": {
+            "value": "true",
+            "value_src": "default"
+          },
+          "DATA_WIDTH": {
+            "value": "8",
+            "value_src": "default"
+          },
+          "MEMORY_TYPE": {
+            "value": "COMPONENTS",
+            "value_src": "default"
+          },
+          "MEM_ADDR_MAP": {
+            "value": "ROW_COLUMN_BANK",
+            "value_src": "default"
+          },
+          "SLOT": {
+            "value": "Single",
+            "value_src": "default"
+          },
+          "TIMEPERIOD_PS": {
+            "value": "1250",
+            "value_src": "default"
+          }
+        }
       },
       "FIXED_IO": {
         "mode": "Master",
-        "vlnv": "xilinx.com:display_processing_system7:fixedio_rtl:1.0"
+        "vlnv": "xilinx.com:display_processing_system7:fixedio_rtl:1.0",
+        "parameters": {
+          "CAN_DEBUG": {
+            "value": "false",
+            "value_src": "default"
+          }
+        }
       }
     },
     "ports": {
@@ -200,97 +257,211 @@
         "type": "data",
         "direction": "I",
         "left": "7",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "adc_clkout": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "adc_sck": {
         "type": "data",
-        "direction": "O"
+        "direction": "O",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "adc_cnv": {
         "type": "data",
-        "direction": "O"
+        "direction": "O",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "encoder_1z": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "encoder_2z": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "encoder_2b": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "encoder_2a": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "encoder_1a": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "encoder_1b": {
         "type": "data",
-        "direction": "I"
+        "direction": "I",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter8_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter7_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter6_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter5_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter4_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter3_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter2_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter1_pwm": {
         "type": "data",
         "direction": "O",
         "left": "5",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "user_led_din": {
         "type": "data",
         "direction": "O",
         "left": "0",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "inverter_sts_a": {
         "direction": "IO",
@@ -316,52 +487,104 @@
         "type": "data",
         "direction": "I",
         "left": "2",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "gpio2_in": {
         "type": "data",
         "direction": "I",
         "left": "2",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "gpio3_in": {
         "type": "data",
         "direction": "I",
         "left": "2",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "gpio4_in": {
         "type": "data",
         "direction": "I",
         "left": "2",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "gpio1_out": {
         "type": "data",
         "direction": "O",
         "left": "2",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "gpio2_out": {
         "type": "data",
         "direction": "O",
         "left": "2",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "gpio3_out": {
         "type": "data",
         "direction": "O",
         "left": "2",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       },
       "gpio4_out": {
         "type": "data",
         "direction": "O",
         "left": "2",
-        "right": "0"
+        "right": "0",
+        "parameters": {
+          "LAYERED_METADATA": {
+            "value": "undef",
+            "value_src": "default"
+          }
+        }
       }
     },
     "components": {
+      "amdc_encoder_0": {
+        "vlnv": "wisc.edu:user:amdc_encoder:1.0",
+        "xci_name": "amdc_reve_amdc_encoder_0_0"
+      },
       "xlconstant_2": {
         "vlnv": "xilinx.com:ip:xlconstant:1.1",
         "xci_name": "amdc_reve_xlconstant_2_0",
@@ -1538,7 +1761,7 @@
             "xci_name": "amdc_reve_ps7_0_axi_periph_0",
             "parameters": {
               "NUM_MI": {
-                "value": "34"
+                "value": "33"
               },
               "S00_HAS_DATA_FIFO": {
                 "value": "2"
@@ -2301,7 +2524,7 @@
                 "xci_name": "amdc_reve_tier2_xbar_3_0",
                 "parameters": {
                   "NUM_MI": {
-                    "value": "8"
+                    "value": "7"
                   },
                   "NUM_SI": {
                     "value": "1"
@@ -2660,16 +2883,16 @@
                       "s00_data_fifo/M_AXI"
                     ]
                   },
-                  "s00_couplers_to_auto_pc": {
-                    "interface_ports": [
-                      "S_AXI",
-                      "auto_pc/S_AXI"
-                    ]
-                  },
                   "auto_pc_to_s00_data_fifo": {
                     "interface_ports": [
                       "s00_data_fifo/S_AXI",
                       "auto_pc/M_AXI"
+                    ]
+                  },
+                  "s00_couplers_to_auto_pc": {
+                    "interface_ports": [
+                      "S_AXI",
+                      "auto_pc/S_AXI"
                     ]
                   }
                 },
@@ -4484,76 +4707,118 @@
               }
             },
             "interface_nets": {
-              "tier2_xbar_2_to_m21_couplers": {
+              "xbar_to_i00_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_2/M05_AXI",
-                  "m21_couplers/S_AXI"
+                  "xbar/M00_AXI",
+                  "i00_couplers/S_AXI"
                 ]
               },
-              "m21_couplers_to_ps7_0_axi_periph": {
+              "i00_couplers_to_tier2_xbar_0": {
                 "interface_ports": [
-                  "M21_AXI",
-                  "m21_couplers/M_AXI"
+                  "i00_couplers/M_AXI",
+                  "tier2_xbar_0/S00_AXI"
                 ]
               },
-              "m22_couplers_to_ps7_0_axi_periph": {
+              "xbar_to_i01_couplers": {
                 "interface_ports": [
-                  "M22_AXI",
-                  "m22_couplers/M_AXI"
+                  "xbar/M01_AXI",
+                  "i01_couplers/S_AXI"
                 ]
               },
-              "tier2_xbar_2_to_m22_couplers": {
+              "i01_couplers_to_tier2_xbar_1": {
                 "interface_ports": [
-                  "tier2_xbar_2/M06_AXI",
-                  "m22_couplers/S_AXI"
+                  "i01_couplers/M_AXI",
+                  "tier2_xbar_1/S00_AXI"
                 ]
               },
-              "m23_couplers_to_ps7_0_axi_periph": {
+              "xbar_to_i02_couplers": {
                 "interface_ports": [
-                  "M23_AXI",
-                  "m23_couplers/M_AXI"
+                  "xbar/M02_AXI",
+                  "i02_couplers/S_AXI"
                 ]
               },
-              "tier2_xbar_2_to_m23_couplers": {
+              "i02_couplers_to_tier2_xbar_2": {
                 "interface_ports": [
-                  "tier2_xbar_2/M07_AXI",
-                  "m23_couplers/S_AXI"
+                  "i02_couplers/M_AXI",
+                  "tier2_xbar_2/S00_AXI"
                 ]
               },
-              "tier2_xbar_3_to_m24_couplers": {
+              "xbar_to_i03_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_3/M00_AXI",
-                  "m24_couplers/S_AXI"
+                  "xbar/M03_AXI",
+                  "i03_couplers/S_AXI"
                 ]
               },
-              "m24_couplers_to_ps7_0_axi_periph": {
+              "i03_couplers_to_tier2_xbar_3": {
                 "interface_ports": [
-                  "M24_AXI",
-                  "m24_couplers/M_AXI"
+                  "i03_couplers/M_AXI",
+                  "tier2_xbar_3/S00_AXI"
                 ]
               },
-              "m25_couplers_to_ps7_0_axi_periph": {
+              "xbar_to_i04_couplers": {
                 "interface_ports": [
-                  "M25_AXI",
-                  "m25_couplers/M_AXI"
+                  "xbar/M04_AXI",
+                  "i04_couplers/S_AXI"
                 ]
               },
-              "tier2_xbar_3_to_m25_couplers": {
+              "i04_couplers_to_tier2_xbar_4": {
                 "interface_ports": [
-                  "tier2_xbar_3/M01_AXI",
-                  "m25_couplers/S_AXI"
+                  "i04_couplers/M_AXI",
+                  "tier2_xbar_4/S00_AXI"
                 ]
               },
-              "m26_couplers_to_ps7_0_axi_periph": {
+              "m29_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M26_AXI",
-                  "m26_couplers/M_AXI"
+                  "M29_AXI",
+                  "m29_couplers/M_AXI"
                 ]
               },
-              "ps7_0_axi_periph_to_s00_couplers": {
+              "tier2_xbar_3_to_m28_couplers": {
                 "interface_ports": [
-                  "S00_AXI",
-                  "s00_couplers/S_AXI"
+                  "tier2_xbar_3/M04_AXI",
+                  "m28_couplers/S_AXI"
+                ]
+              },
+              "tier2_xbar_3_to_m29_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_3/M05_AXI",
+                  "m29_couplers/S_AXI"
+                ]
+              },
+              "m30_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M30_AXI",
+                  "m30_couplers/M_AXI"
+                ]
+              },
+              "tier2_xbar_3_to_m30_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_3/M06_AXI",
+                  "m30_couplers/S_AXI"
+                ]
+              },
+              "m31_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M31_AXI",
+                  "m31_couplers/M_AXI"
+                ]
+              },
+              "m32_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M32_AXI",
+                  "m32_couplers/M_AXI"
+                ]
+              },
+              "tier2_xbar_4_to_m31_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_4/M00_AXI",
+                  "m31_couplers/S_AXI"
+                ]
+              },
+              "tier2_xbar_4_to_m32_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_4/M01_AXI",
+                  "m32_couplers/S_AXI"
                 ]
               },
               "s00_couplers_to_xbar": {
@@ -4568,16 +4833,28 @@
                   "m00_couplers/M_AXI"
                 ]
               },
-              "m01_couplers_to_ps7_0_axi_periph": {
+              "ps7_0_axi_periph_to_s00_couplers": {
                 "interface_ports": [
-                  "M01_AXI",
-                  "m01_couplers/M_AXI"
+                  "S00_AXI",
+                  "s00_couplers/S_AXI"
                 ]
               },
               "tier2_xbar_0_to_m00_couplers": {
                 "interface_ports": [
                   "tier2_xbar_0/M00_AXI",
                   "m00_couplers/S_AXI"
+                ]
+              },
+              "m01_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M01_AXI",
+                  "m01_couplers/M_AXI"
+                ]
+              },
+              "m02_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M02_AXI",
+                  "m02_couplers/M_AXI"
                 ]
               },
               "tier2_xbar_0_to_m01_couplers": {
@@ -4592,16 +4869,10 @@
                   "m02_couplers/S_AXI"
                 ]
               },
-              "m02_couplers_to_ps7_0_axi_periph": {
+              "m03_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M02_AXI",
-                  "m02_couplers/M_AXI"
-                ]
-              },
-              "m04_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M04_AXI",
-                  "m04_couplers/M_AXI"
+                  "M03_AXI",
+                  "m03_couplers/M_AXI"
                 ]
               },
               "tier2_xbar_0_to_m03_couplers": {
@@ -4610,10 +4881,10 @@
                   "m03_couplers/S_AXI"
                 ]
               },
-              "m03_couplers_to_ps7_0_axi_periph": {
+              "m04_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M03_AXI",
-                  "m03_couplers/M_AXI"
+                  "M04_AXI",
+                  "m04_couplers/M_AXI"
                 ]
               },
               "tier2_xbar_0_to_m04_couplers": {
@@ -4634,22 +4905,16 @@
                   "m05_couplers/S_AXI"
                 ]
               },
-              "tier2_xbar_0_to_m06_couplers": {
-                "interface_ports": [
-                  "tier2_xbar_0/M06_AXI",
-                  "m06_couplers/S_AXI"
-                ]
-              },
               "m06_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
                   "M06_AXI",
                   "m06_couplers/M_AXI"
                 ]
               },
-              "tier2_xbar_0_to_m07_couplers": {
+              "tier2_xbar_0_to_m06_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_0/M07_AXI",
-                  "m07_couplers/S_AXI"
+                  "tier2_xbar_0/M06_AXI",
+                  "m06_couplers/S_AXI"
                 ]
               },
               "m07_couplers_to_ps7_0_axi_periph": {
@@ -4658,10 +4923,10 @@
                   "m07_couplers/M_AXI"
                 ]
               },
-              "tier2_xbar_1_to_m08_couplers": {
+              "tier2_xbar_0_to_m07_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_1/M00_AXI",
-                  "m08_couplers/S_AXI"
+                  "tier2_xbar_0/M07_AXI",
+                  "m07_couplers/S_AXI"
                 ]
               },
               "m08_couplers_to_ps7_0_axi_periph": {
@@ -4670,16 +4935,10 @@
                   "m08_couplers/M_AXI"
                 ]
               },
-              "m10_couplers_to_ps7_0_axi_periph": {
+              "tier2_xbar_1_to_m08_couplers": {
                 "interface_ports": [
-                  "M10_AXI",
-                  "m10_couplers/M_AXI"
-                ]
-              },
-              "tier2_xbar_1_to_m09_couplers": {
-                "interface_ports": [
-                  "tier2_xbar_1/M01_AXI",
-                  "m09_couplers/S_AXI"
+                  "tier2_xbar_1/M00_AXI",
+                  "m08_couplers/S_AXI"
                 ]
               },
               "m09_couplers_to_ps7_0_axi_periph": {
@@ -4688,10 +4947,28 @@
                   "m09_couplers/M_AXI"
                 ]
               },
+              "tier2_xbar_1_to_m09_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_1/M01_AXI",
+                  "m09_couplers/S_AXI"
+                ]
+              },
+              "m10_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M10_AXI",
+                  "m10_couplers/M_AXI"
+                ]
+              },
               "tier2_xbar_1_to_m10_couplers": {
                 "interface_ports": [
                   "tier2_xbar_1/M02_AXI",
                   "m10_couplers/S_AXI"
+                ]
+              },
+              "m11_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M11_AXI",
+                  "m11_couplers/M_AXI"
                 ]
               },
               "tier2_xbar_1_to_m11_couplers": {
@@ -4706,28 +4983,64 @@
                   "m12_couplers/M_AXI"
                 ]
               },
-              "m11_couplers_to_ps7_0_axi_periph": {
+              "tier2_xbar_1_to_m12_couplers": {
                 "interface_ports": [
-                  "M11_AXI",
-                  "m11_couplers/M_AXI"
+                  "tier2_xbar_1/M04_AXI",
+                  "m12_couplers/S_AXI"
                 ]
               },
-              "tier2_xbar_3_to_m26_couplers": {
+              "m13_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "tier2_xbar_3/M02_AXI",
-                  "m26_couplers/S_AXI"
+                  "M13_AXI",
+                  "m13_couplers/M_AXI"
                 ]
               },
-              "m27_couplers_to_ps7_0_axi_periph": {
+              "m14_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M27_AXI",
-                  "m27_couplers/M_AXI"
+                  "M14_AXI",
+                  "m14_couplers/M_AXI"
                 ]
               },
-              "tier2_xbar_3_to_m27_couplers": {
+              "tier2_xbar_1_to_m13_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_3/M03_AXI",
-                  "m27_couplers/S_AXI"
+                  "tier2_xbar_1/M05_AXI",
+                  "m13_couplers/S_AXI"
+                ]
+              },
+              "tier2_xbar_1_to_m14_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_1/M06_AXI",
+                  "m14_couplers/S_AXI"
+                ]
+              },
+              "m15_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M15_AXI",
+                  "m15_couplers/M_AXI"
+                ]
+              },
+              "tier2_xbar_1_to_m15_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_1/M07_AXI",
+                  "m15_couplers/S_AXI"
+                ]
+              },
+              "m16_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M16_AXI",
+                  "m16_couplers/M_AXI"
+                ]
+              },
+              "tier2_xbar_2_to_m16_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_2/M00_AXI",
+                  "m16_couplers/S_AXI"
+                ]
+              },
+              "m17_couplers_to_ps7_0_axi_periph": {
+                "interface_ports": [
+                  "M17_AXI",
+                  "m17_couplers/M_AXI"
                 ]
               },
               "m28_couplers_to_ps7_0_axi_periph": {
@@ -4736,16 +5049,28 @@
                   "m28_couplers/M_AXI"
                 ]
               },
-              "tier2_xbar_2_to_m18_couplers": {
+              "m18_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "tier2_xbar_2/M02_AXI",
-                  "m18_couplers/S_AXI"
+                  "M18_AXI",
+                  "m18_couplers/M_AXI"
+                ]
+              },
+              "tier2_xbar_2_to_m17_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_2/M01_AXI",
+                  "m17_couplers/S_AXI"
                 ]
               },
               "m19_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
                   "M19_AXI",
                   "m19_couplers/M_AXI"
+                ]
+              },
+              "tier2_xbar_2_to_m18_couplers": {
+                "interface_ports": [
+                  "tier2_xbar_2/M02_AXI",
+                  "m18_couplers/S_AXI"
                 ]
               },
               "tier2_xbar_2_to_m19_couplers": {
@@ -4766,190 +5091,88 @@
                   "m20_couplers/S_AXI"
                 ]
               },
-              "tier2_xbar_1_to_m12_couplers": {
+              "m21_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "tier2_xbar_1/M04_AXI",
-                  "m12_couplers/S_AXI"
+                  "M21_AXI",
+                  "m21_couplers/M_AXI"
                 ]
               },
-              "tier2_xbar_1_to_m13_couplers": {
+              "m22_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "tier2_xbar_1/M05_AXI",
-                  "m13_couplers/S_AXI"
+                  "M22_AXI",
+                  "m22_couplers/M_AXI"
                 ]
               },
-              "m13_couplers_to_ps7_0_axi_periph": {
+              "tier2_xbar_2_to_m21_couplers": {
                 "interface_ports": [
-                  "M13_AXI",
-                  "m13_couplers/M_AXI"
+                  "tier2_xbar_2/M05_AXI",
+                  "m21_couplers/S_AXI"
                 ]
               },
-              "tier2_xbar_1_to_m14_couplers": {
+              "tier2_xbar_2_to_m22_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_1/M06_AXI",
-                  "m14_couplers/S_AXI"
+                  "tier2_xbar_2/M06_AXI",
+                  "m22_couplers/S_AXI"
                 ]
               },
-              "m16_couplers_to_ps7_0_axi_periph": {
+              "m23_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M16_AXI",
-                  "m16_couplers/M_AXI"
+                  "M23_AXI",
+                  "m23_couplers/M_AXI"
                 ]
               },
-              "m14_couplers_to_ps7_0_axi_periph": {
+              "tier2_xbar_2_to_m23_couplers": {
                 "interface_ports": [
-                  "M14_AXI",
-                  "m14_couplers/M_AXI"
+                  "tier2_xbar_2/M07_AXI",
+                  "m23_couplers/S_AXI"
                 ]
               },
-              "tier2_xbar_1_to_m15_couplers": {
+              "m24_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "tier2_xbar_1/M07_AXI",
-                  "m15_couplers/S_AXI"
+                  "M24_AXI",
+                  "m24_couplers/M_AXI"
                 ]
               },
-              "tier2_xbar_2_to_m16_couplers": {
+              "tier2_xbar_3_to_m24_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_2/M00_AXI",
-                  "m16_couplers/S_AXI"
+                  "tier2_xbar_3/M00_AXI",
+                  "m24_couplers/S_AXI"
                 ]
               },
-              "m15_couplers_to_ps7_0_axi_periph": {
+              "m25_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M15_AXI",
-                  "m15_couplers/M_AXI"
+                  "M25_AXI",
+                  "m25_couplers/M_AXI"
                 ]
               },
-              "m17_couplers_to_ps7_0_axi_periph": {
+              "m26_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "M17_AXI",
-                  "m17_couplers/M_AXI"
+                  "M26_AXI",
+                  "m26_couplers/M_AXI"
                 ]
               },
-              "tier2_xbar_2_to_m17_couplers": {
+              "tier2_xbar_3_to_m25_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_2/M01_AXI",
-                  "m17_couplers/S_AXI"
+                  "tier2_xbar_3/M01_AXI",
+                  "m25_couplers/S_AXI"
                 ]
               },
-              "m18_couplers_to_ps7_0_axi_periph": {
+              "tier2_xbar_3_to_m26_couplers": {
                 "interface_ports": [
-                  "M18_AXI",
-                  "m18_couplers/M_AXI"
+                  "tier2_xbar_3/M02_AXI",
+                  "m26_couplers/S_AXI"
                 ]
               },
-              "tier2_xbar_3_to_m30_couplers": {
+              "m27_couplers_to_ps7_0_axi_periph": {
                 "interface_ports": [
-                  "tier2_xbar_3/M06_AXI",
-                  "m30_couplers/S_AXI"
+                  "M27_AXI",
+                  "m27_couplers/M_AXI"
                 ]
               },
-              "tier2_xbar_4_to_m31_couplers": {
+              "tier2_xbar_3_to_m27_couplers": {
                 "interface_ports": [
-                  "tier2_xbar_4/M00_AXI",
-                  "m31_couplers/S_AXI"
-                ]
-              },
-              "m31_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M31_AXI",
-                  "m31_couplers/M_AXI"
-                ]
-              },
-              "m32_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M32_AXI",
-                  "m32_couplers/M_AXI"
-                ]
-              },
-              "tier2_xbar_4_to_m32_couplers": {
-                "interface_ports": [
-                  "tier2_xbar_4/M01_AXI",
-                  "m32_couplers/S_AXI"
-                ]
-              },
-              "tier2_xbar_3_to_m28_couplers": {
-                "interface_ports": [
-                  "tier2_xbar_3/M04_AXI",
-                  "m28_couplers/S_AXI"
-                ]
-              },
-              "m30_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M30_AXI",
-                  "m30_couplers/M_AXI"
-                ]
-              },
-              "m29_couplers_to_ps7_0_axi_periph": {
-                "interface_ports": [
-                  "M29_AXI",
-                  "m29_couplers/M_AXI"
-                ]
-              },
-              "tier2_xbar_3_to_m29_couplers": {
-                "interface_ports": [
-                  "tier2_xbar_3/M05_AXI",
-                  "m29_couplers/S_AXI"
-                ]
-              },
-              "xbar_to_i00_couplers": {
-                "interface_ports": [
-                  "xbar/M00_AXI",
-                  "i00_couplers/S_AXI"
-                ]
-              },
-              "i00_couplers_to_tier2_xbar_0": {
-                "interface_ports": [
-                  "i00_couplers/M_AXI",
-                  "tier2_xbar_0/S00_AXI"
-                ]
-              },
-              "xbar_to_i01_couplers": {
-                "interface_ports": [
-                  "xbar/M01_AXI",
-                  "i01_couplers/S_AXI"
-                ]
-              },
-              "xbar_to_i02_couplers": {
-                "interface_ports": [
-                  "xbar/M02_AXI",
-                  "i02_couplers/S_AXI"
-                ]
-              },
-              "i01_couplers_to_tier2_xbar_1": {
-                "interface_ports": [
-                  "i01_couplers/M_AXI",
-                  "tier2_xbar_1/S00_AXI"
-                ]
-              },
-              "xbar_to_i03_couplers": {
-                "interface_ports": [
-                  "xbar/M03_AXI",
-                  "i03_couplers/S_AXI"
-                ]
-              },
-              "i02_couplers_to_tier2_xbar_2": {
-                "interface_ports": [
-                  "i02_couplers/M_AXI",
-                  "tier2_xbar_2/S00_AXI"
-                ]
-              },
-              "xbar_to_i04_couplers": {
-                "interface_ports": [
-                  "xbar/M04_AXI",
-                  "i04_couplers/S_AXI"
-                ]
-              },
-              "i04_couplers_to_tier2_xbar_4": {
-                "interface_ports": [
-                  "i04_couplers/M_AXI",
-                  "tier2_xbar_4/S00_AXI"
-                ]
-              },
-              "i03_couplers_to_tier2_xbar_3": {
-                "interface_ports": [
-                  "i03_couplers/M_AXI",
-                  "tier2_xbar_3/S00_AXI"
+                  "tier2_xbar_3/M03_AXI",
+                  "m27_couplers/S_AXI"
                 ]
               }
             },
@@ -5476,82 +5699,10 @@
           }
         },
         "interface_nets": {
-          "Conn28": {
-            "interface_ports": [
-              "M28_AXI",
-              "ps7_0_axi_periph/M28_AXI"
-            ]
-          },
-          "Conn12": {
-            "interface_ports": [
-              "M11_AXI",
-              "ps7_0_axi_periph/M11_AXI"
-            ]
-          },
-          "processing_system7_0_FIXED_IO": {
-            "interface_ports": [
-              "FIXED_IO",
-              "processing_system7_0/FIXED_IO"
-            ]
-          },
-          "Conn1": {
-            "interface_ports": [
-              "M00_AXI",
-              "ps7_0_axi_periph/M00_AXI"
-            ]
-          },
-          "Conn21": {
-            "interface_ports": [
-              "M21_AXI",
-              "ps7_0_axi_periph/M21_AXI"
-            ]
-          },
-          "ps7_0_axi_periph_M30_AXI": {
-            "interface_ports": [
-              "M30_AXI",
-              "ps7_0_axi_periph/M30_AXI"
-            ]
-          },
-          "Conn18": {
-            "interface_ports": [
-              "M18_AXI",
-              "ps7_0_axi_periph/M18_AXI"
-            ]
-          },
-          "Conn2": {
-            "interface_ports": [
-              "M01_AXI",
-              "ps7_0_axi_periph/M01_AXI"
-            ]
-          },
-          "ps7_0_axi_periph_M29_AXI": {
-            "interface_ports": [
-              "M29_AXI",
-              "ps7_0_axi_periph/M29_AXI"
-            ]
-          },
-          "Conn9": {
-            "interface_ports": [
-              "M08_AXI",
-              "ps7_0_axi_periph/M08_AXI"
-            ]
-          },
-          "Conn3": {
-            "interface_ports": [
-              "M02_AXI",
-              "ps7_0_axi_periph/M02_AXI"
-            ]
-          },
           "Conn16": {
             "interface_ports": [
               "M16_AXI",
               "ps7_0_axi_periph/M16_AXI"
-            ]
-          },
-          "Conn13": {
-            "interface_ports": [
-              "M12_AXI",
-              "ps7_0_axi_periph/M12_AXI"
             ]
           },
           "ps7_0_axi_periph_M31_AXI": {
@@ -5566,16 +5717,34 @@
               "ps7_0_axi_periph/M06_AXI"
             ]
           },
-          "Conn15": {
+          "Conn13": {
             "interface_ports": [
-              "M15_AXI",
-              "ps7_0_axi_periph/M15_AXI"
+              "M12_AXI",
+              "ps7_0_axi_periph/M12_AXI"
+            ]
+          },
+          "Conn9": {
+            "interface_ports": [
+              "M08_AXI",
+              "ps7_0_axi_periph/M08_AXI"
+            ]
+          },
+          "Conn3": {
+            "interface_ports": [
+              "M02_AXI",
+              "ps7_0_axi_periph/M02_AXI"
             ]
           },
           "Conn19": {
             "interface_ports": [
               "M19_AXI",
               "ps7_0_axi_periph/M19_AXI"
+            ]
+          },
+          "Conn15": {
+            "interface_ports": [
+              "M15_AXI",
+              "ps7_0_axi_periph/M15_AXI"
             ]
           },
           "Conn6": {
@@ -5590,76 +5759,34 @@
               "ps7_0_axi_periph/M27_AXI"
             ]
           },
-          "Conn17": {
+          "Conn1": {
             "interface_ports": [
-              "M17_AXI",
-              "ps7_0_axi_periph/M17_AXI"
+              "M00_AXI",
+              "ps7_0_axi_periph/M00_AXI"
             ]
           },
-          "Conn11": {
+          "ps7_0_axi_periph_M30_AXI": {
             "interface_ports": [
-              "M10_AXI",
-              "ps7_0_axi_periph/M10_AXI"
+              "M30_AXI",
+              "ps7_0_axi_periph/M30_AXI"
             ]
           },
-          "processing_system7_0_DDR": {
+          "Conn18": {
             "interface_ports": [
-              "DDR",
-              "processing_system7_0/DDR"
+              "M18_AXI",
+              "ps7_0_axi_periph/M18_AXI"
             ]
           },
-          "Conn8": {
+          "processing_system7_0_FIXED_IO": {
             "interface_ports": [
-              "M07_AXI",
-              "ps7_0_axi_periph/M07_AXI"
+              "FIXED_IO",
+              "processing_system7_0/FIXED_IO"
             ]
           },
-          "ps7_0_axi_periph_M32_AXI": {
+          "Conn12": {
             "interface_ports": [
-              "M32_AXI",
-              "ps7_0_axi_periph/M32_AXI"
-            ]
-          },
-          "Conn5": {
-            "interface_ports": [
-              "M04_AXI",
-              "ps7_0_axi_periph/M04_AXI"
-            ]
-          },
-          "Conn20": {
-            "interface_ports": [
-              "M20_AXI",
-              "ps7_0_axi_periph/M20_AXI"
-            ]
-          },
-          "Conn24": {
-            "interface_ports": [
-              "M24_AXI",
-              "ps7_0_axi_periph/M24_AXI"
-            ]
-          },
-          "processing_system7_0_M_AXI_GP0": {
-            "interface_ports": [
-              "processing_system7_0/M_AXI_GP0",
-              "ps7_0_axi_periph/S00_AXI"
-            ]
-          },
-          "Conn23": {
-            "interface_ports": [
-              "M23_AXI",
-              "ps7_0_axi_periph/M23_AXI"
-            ]
-          },
-          "ps7_0_axi_periph_M13_AXI": {
-            "interface_ports": [
-              "M13_AXI",
-              "ps7_0_axi_periph/M13_AXI"
-            ]
-          },
-          "Conn4": {
-            "interface_ports": [
-              "M03_AXI",
-              "ps7_0_axi_periph/M03_AXI"
+              "M11_AXI",
+              "ps7_0_axi_periph/M11_AXI"
             ]
           },
           "Conn14": {
@@ -5674,10 +5801,52 @@
               "ps7_0_axi_periph/M22_AXI"
             ]
           },
-          "Conn10": {
+          "Conn17": {
             "interface_ports": [
-              "M09_AXI",
-              "ps7_0_axi_periph/M09_AXI"
+              "M17_AXI",
+              "ps7_0_axi_periph/M17_AXI"
+            ]
+          },
+          "processing_system7_0_DDR": {
+            "interface_ports": [
+              "DDR",
+              "processing_system7_0/DDR"
+            ]
+          },
+          "Conn11": {
+            "interface_ports": [
+              "M10_AXI",
+              "ps7_0_axi_periph/M10_AXI"
+            ]
+          },
+          "Conn8": {
+            "interface_ports": [
+              "M07_AXI",
+              "ps7_0_axi_periph/M07_AXI"
+            ]
+          },
+          "ps7_0_axi_periph_M32_AXI": {
+            "interface_ports": [
+              "M32_AXI",
+              "ps7_0_axi_periph/M32_AXI"
+            ]
+          },
+          "Conn25": {
+            "interface_ports": [
+              "M25_AXI",
+              "ps7_0_axi_periph/M25_AXI"
+            ]
+          },
+          "Conn28": {
+            "interface_ports": [
+              "M28_AXI",
+              "ps7_0_axi_periph/M28_AXI"
+            ]
+          },
+          "Conn21": {
+            "interface_ports": [
+              "M21_AXI",
+              "ps7_0_axi_periph/M21_AXI"
             ]
           },
           "Conn26": {
@@ -5686,10 +5855,64 @@
               "ps7_0_axi_periph/M26_AXI"
             ]
           },
-          "Conn25": {
+          "Conn10": {
             "interface_ports": [
-              "M25_AXI",
-              "ps7_0_axi_periph/M25_AXI"
+              "M09_AXI",
+              "ps7_0_axi_periph/M09_AXI"
+            ]
+          },
+          "Conn24": {
+            "interface_ports": [
+              "M24_AXI",
+              "ps7_0_axi_periph/M24_AXI"
+            ]
+          },
+          "ps7_0_axi_periph_M13_AXI": {
+            "interface_ports": [
+              "M13_AXI",
+              "ps7_0_axi_periph/M13_AXI"
+            ]
+          },
+          "Conn23": {
+            "interface_ports": [
+              "M23_AXI",
+              "ps7_0_axi_periph/M23_AXI"
+            ]
+          },
+          "Conn4": {
+            "interface_ports": [
+              "M03_AXI",
+              "ps7_0_axi_periph/M03_AXI"
+            ]
+          },
+          "Conn5": {
+            "interface_ports": [
+              "M04_AXI",
+              "ps7_0_axi_periph/M04_AXI"
+            ]
+          },
+          "Conn20": {
+            "interface_ports": [
+              "M20_AXI",
+              "ps7_0_axi_periph/M20_AXI"
+            ]
+          },
+          "processing_system7_0_M_AXI_GP0": {
+            "interface_ports": [
+              "processing_system7_0/M_AXI_GP0",
+              "ps7_0_axi_periph/S00_AXI"
+            ]
+          },
+          "Conn2": {
+            "interface_ports": [
+              "M01_AXI",
+              "ps7_0_axi_periph/M01_AXI"
+            ]
+          },
+          "ps7_0_axi_periph_M29_AXI": {
+            "interface_ports": [
+              "M29_AXI",
+              "ps7_0_axi_periph/M29_AXI"
             ]
           }
         },
@@ -5920,10 +6143,10 @@
           }
         },
         "interface_nets": {
-          "ps7_0_axi_periph_M02_AXI": {
+          "ps7_0_axi_periph_M06_AXI": {
             "interface_ports": [
-              "S00_AXI",
-              "amdc_inverters_0/S00_AXI"
+              "S00_AXI1",
+              "amdc_pwm_mux_0/S00_AXI"
             ]
           },
           "Conn1": {
@@ -5932,10 +6155,10 @@
               "amdc_inv_status_mux_0/S00_AXI"
             ]
           },
-          "ps7_0_axi_periph_M06_AXI": {
+          "ps7_0_axi_periph_M02_AXI": {
             "interface_ports": [
-              "S00_AXI1",
-              "amdc_pwm_mux_0/S00_AXI"
+              "S00_AXI",
+              "amdc_inverters_0/S00_AXI"
             ]
           }
         },
@@ -6566,11 +6789,11 @@
           },
           "xlconstant_3": {
             "vlnv": "xilinx.com:ip:xlconstant:1.1",
-            "xci_name": "amdc_reve_xlconstant_3_5"
+            "xci_name": "amdc_reve_xlconstant_3_1"
           },
           "xlslice_3": {
             "vlnv": "xilinx.com:ip:xlslice:1.0",
-            "xci_name": "amdc_reve_xlslice_3_4",
+            "xci_name": "amdc_reve_xlslice_3_0",
             "parameters": {
               "DIN_FROM": {
                 "value": "0"
@@ -6589,18 +6812,6 @@
           }
         },
         "interface_nets": {
-          "S00_AXI1_1": {
-            "interface_ports": [
-              "S00_AXI1",
-              "amdc_eddy_current_se_0/S00_AXI"
-            ]
-          },
-          "S00_AXI5_1": {
-            "interface_ports": [
-              "S00_AXI5",
-              "amdc_gpio_direct_0/S00_AXI"
-            ]
-          },
           "S00_AXI3_1": {
             "interface_ports": [
               "S00_AXI3",
@@ -6613,16 +6824,28 @@
               "hier_amds_0/S00_AXI"
             ]
           },
-          "S00_AXI4_1": {
+          "S00_AXI1_1": {
             "interface_ports": [
-              "S00_AXI4",
-              "hier_ild1420_0/S00_AXI1"
+              "S00_AXI1",
+              "amdc_eddy_current_se_0/S00_AXI"
+            ]
+          },
+          "S00_AXI5_1": {
+            "interface_ports": [
+              "S00_AXI5",
+              "amdc_gpio_direct_0/S00_AXI"
             ]
           },
           "hier_ps_M48_AXI": {
             "interface_ports": [
               "S00_AXI",
               "amdc_gp3io_mux_0/S00_AXI"
+            ]
+          },
+          "S00_AXI4_1": {
+            "interface_ports": [
+              "S00_AXI4",
+              "hier_ild1420_0/S00_AXI1"
             ]
           }
         },
@@ -7325,11 +7548,11 @@
           },
           "xlconstant_3": {
             "vlnv": "xilinx.com:ip:xlconstant:1.1",
-            "xci_name": "amdc_reve_xlconstant_3_6"
+            "xci_name": "amdc_reve_xlconstant_3_2"
           },
           "xlslice_3": {
             "vlnv": "xilinx.com:ip:xlslice:1.0",
-            "xci_name": "amdc_reve_xlslice_3_5",
+            "xci_name": "amdc_reve_xlslice_3_1",
             "parameters": {
               "DIN_FROM": {
                 "value": "0"
@@ -7360,6 +7583,12 @@
               "amdc_gp3io_mux_0/S00_AXI"
             ]
           },
+          "S00_AXI2_1": {
+            "interface_ports": [
+              "S00_AXI2",
+              "hier_amds_0/S00_AXI"
+            ]
+          },
           "S00_AXI1_1": {
             "interface_ports": [
               "S00_AXI1",
@@ -7376,12 +7605,6 @@
             "interface_ports": [
               "S00_AXI4",
               "hier_ild1420_0/S00_AXI1"
-            ]
-          },
-          "S00_AXI2_1": {
-            "interface_ports": [
-              "S00_AXI2",
-              "hier_amds_0/S00_AXI"
             ]
           }
         },
@@ -7973,11 +8196,11 @@
           },
           "xlconstant_3": {
             "vlnv": "xilinx.com:ip:xlconstant:1.1",
-            "xci_name": "amdc_reve_xlconstant_3_7"
+            "xci_name": "amdc_reve_xlconstant_3_3"
           },
           "xlslice_3": {
             "vlnv": "xilinx.com:ip:xlslice:1.0",
-            "xci_name": "amdc_reve_xlslice_3_6",
+            "xci_name": "amdc_reve_xlslice_3_2",
             "parameters": {
               "DIN_FROM": {
                 "value": "0"
@@ -7996,6 +8219,18 @@
           }
         },
         "interface_nets": {
+          "S00_AXI1_1": {
+            "interface_ports": [
+              "S00_AXI1",
+              "amdc_eddy_current_se_0/S00_AXI"
+            ]
+          },
+          "hier_ps_M48_AXI": {
+            "interface_ports": [
+              "S00_AXI",
+              "amdc_gp3io_mux_0/S00_AXI"
+            ]
+          },
           "S00_AXI2_1": {
             "interface_ports": [
               "S00_AXI2",
@@ -8012,18 +8247,6 @@
             "interface_ports": [
               "S00_AXI3",
               "hier_ild1420_0/S00_AXI"
-            ]
-          },
-          "hier_ps_M48_AXI": {
-            "interface_ports": [
-              "S00_AXI",
-              "amdc_gp3io_mux_0/S00_AXI"
-            ]
-          },
-          "S00_AXI1_1": {
-            "interface_ports": [
-              "S00_AXI1",
-              "amdc_eddy_current_se_0/S00_AXI"
             ]
           },
           "S00_AXI5_1": {
@@ -8621,11 +8844,11 @@
           },
           "xlconstant_3": {
             "vlnv": "xilinx.com:ip:xlconstant:1.1",
-            "xci_name": "amdc_reve_xlconstant_3_8"
+            "xci_name": "amdc_reve_xlconstant_3_4"
           },
           "xlslice_3": {
             "vlnv": "xilinx.com:ip:xlslice:1.0",
-            "xci_name": "amdc_reve_xlslice_3_7",
+            "xci_name": "amdc_reve_xlslice_3_3",
             "parameters": {
               "DIN_FROM": {
                 "value": "0"
@@ -8662,16 +8885,16 @@
               "amdc_gp3io_mux_0/S00_AXI"
             ]
           },
-          "S00_AXI5_1": {
-            "interface_ports": [
-              "S00_AXI5",
-              "amdc_gpio_direct_0/S00_AXI"
-            ]
-          },
           "S00_AXI2_1": {
             "interface_ports": [
               "S00_AXI2",
               "hier_amds_0/S00_AXI"
+            ]
+          },
+          "S00_AXI5_1": {
+            "interface_ports": [
+              "S00_AXI5",
+              "amdc_gpio_direct_0/S00_AXI"
             ]
           },
           "S00_AXI3_1": {
@@ -8835,35 +9058,19 @@
             ]
           }
         }
-      },
-      "amdc_encoder_0": {
-        "vlnv": "wisc.edu:user:amdc_encoder:1.0",
-        "xci_name": "amdc_reve_amdc_encoder_0_0"
       }
     },
     "interface_nets": {
-      "S00_AXI_2": {
+      "S00_AXI_4": {
         "interface_ports": [
-          "hier_gpio_0/S00_AXI",
-          "hier_ps/M09_AXI"
+          "hier_gpio_2/S00_AXI",
+          "hier_ps/M19_AXI"
         ]
       },
-      "hier_ps_M36_AXI": {
+      "hier_ps_M32_AXI1": {
         "interface_ports": [
-          "amdc_adc_0/S00_AXI",
-          "hier_ps/M04_AXI"
-        ]
-      },
-      "S00_AXI_3": {
-        "interface_ports": [
-          "hier_gpio_1/S00_AXI",
-          "hier_ps/M14_AXI"
-        ]
-      },
-      "processing_system7_0_DDR": {
-        "interface_ports": [
-          "DDR",
-          "hier_ps/DDR"
+          "hier_ps/M32_AXI",
+          "hier_gpio_3/S00_AXI5"
         ]
       },
       "S00_AXI4_1": {
@@ -8878,52 +9085,28 @@
           "hier_ps/M08_AXI"
         ]
       },
-      "S00_AXI1_3": {
-        "interface_ports": [
-          "hier_gpio_1/S00_AXI1",
-          "hier_ps/M16_AXI"
-        ]
-      },
-      "S00_AXI_5": {
-        "interface_ports": [
-          "hier_gpio_3/S00_AXI",
-          "hier_ps/M24_AXI"
-        ]
-      },
-      "S00_AXI3_2": {
-        "interface_ports": [
-          "hier_gpio_1/S00_AXI3",
-          "hier_ps/M17_AXI"
-        ]
-      },
-      "hier_ps_M29_AXI": {
-        "interface_ports": [
-          "hier_ps/M29_AXI",
-          "hier_gpio_0/S00_AXI5"
-        ]
-      },
-      "hier_ps_M34_AXI": {
-        "interface_ports": [
-          "amdc_encoder_0/S00_AXI",
-          "hier_ps/M02_AXI"
-        ]
-      },
-      "S00_AXI4_4": {
-        "interface_ports": [
-          "hier_gpio_3/S00_AXI4",
-          "hier_ps/M28_AXI"
-        ]
-      },
       "hier_ps_M30_AXI": {
         "interface_ports": [
           "hier_ps/M30_AXI",
           "hier_gpio_1/S00_AXI5"
         ]
       },
-      "hier_ps_M32_AXI1": {
+      "S00_AXI1_5": {
         "interface_ports": [
-          "hier_ps/M32_AXI",
-          "hier_gpio_3/S00_AXI5"
+          "hier_gpio_3/S00_AXI1",
+          "hier_ps/M26_AXI"
+        ]
+      },
+      "hier_ps_M36_AXI": {
+        "interface_ports": [
+          "amdc_adc_0/S00_AXI",
+          "hier_ps/M04_AXI"
+        ]
+      },
+      "S00_AXI_2": {
+        "interface_ports": [
+          "hier_gpio_0/S00_AXI",
+          "hier_ps/M09_AXI"
         ]
       },
       "hier_ps_M32_AXI": {
@@ -8932,10 +9115,124 @@
           "hier_ps/M00_AXI"
         ]
       },
-      "S00_AXI1_5": {
+      "hier_ps_M34_AXI": {
         "interface_ports": [
-          "hier_gpio_3/S00_AXI1",
-          "hier_ps/M26_AXI"
+          "amdc_encoder_0/S00_AXI",
+          "hier_ps/M02_AXI"
+        ]
+      },
+      "S00_AXI3_2": {
+        "interface_ports": [
+          "hier_gpio_1/S00_AXI3",
+          "hier_ps/M17_AXI"
+        ]
+      },
+      "S00_AXI_3": {
+        "interface_ports": [
+          "hier_gpio_1/S00_AXI",
+          "hier_ps/M14_AXI"
+        ]
+      },
+      "S00_AXI_5": {
+        "interface_ports": [
+          "hier_gpio_3/S00_AXI",
+          "hier_ps/M24_AXI"
+        ]
+      },
+      "S00_AXI3_3": {
+        "interface_ports": [
+          "hier_gpio_2/S00_AXI3",
+          "hier_ps/M22_AXI"
+        ]
+      },
+      "S00_AXI1_3": {
+        "interface_ports": [
+          "hier_gpio_1/S00_AXI1",
+          "hier_ps/M16_AXI"
+        ]
+      },
+      "S00_AXI4_4": {
+        "interface_ports": [
+          "hier_gpio_3/S00_AXI4",
+          "hier_ps/M28_AXI"
+        ]
+      },
+      "processing_system7_0_DDR": {
+        "interface_ports": [
+          "DDR",
+          "hier_ps/DDR"
+        ]
+      },
+      "hier_ps_M29_AXI": {
+        "interface_ports": [
+          "hier_ps/M29_AXI",
+          "hier_gpio_0/S00_AXI5"
+        ]
+      },
+      "S00_AXI2_3": {
+        "interface_ports": [
+          "hier_gpio_1/S00_AXI2",
+          "hier_ps/M15_AXI"
+        ]
+      },
+      "S00_AXI1_2": {
+        "interface_ports": [
+          "hier_gpio_0/S00_AXI1",
+          "hier_ps/M11_AXI"
+        ]
+      },
+      "S00_AXI4_2": {
+        "interface_ports": [
+          "hier_gpio_1/S00_AXI4",
+          "hier_ps/M18_AXI"
+        ]
+      },
+      "S00_AXI2_2": {
+        "interface_ports": [
+          "hier_gpio_0/S00_AXI2",
+          "hier_ps/M10_AXI"
+        ]
+      },
+      "S00_AXI1_4": {
+        "interface_ports": [
+          "hier_gpio_2/S00_AXI1",
+          "hier_ps/M21_AXI"
+        ]
+      },
+      "S00_AXI3_1": {
+        "interface_ports": [
+          "hier_gpio_0/S00_AXI3",
+          "hier_ps/M12_AXI"
+        ]
+      },
+      "hier_ps_M35_AXI": {
+        "interface_ports": [
+          "amdc_leds_0/S00_AXI",
+          "hier_ps/M03_AXI"
+        ]
+      },
+      "processing_system7_0_FIXED_IO": {
+        "interface_ports": [
+          "FIXED_IO",
+          "hier_ps/FIXED_IO"
+        ]
+      },
+      "hier_ps_M33_AXI": {
+        "interface_ports": [
+          "hier_timers/S_AXI1",
+          "hier_ps/M01_AXI"
+        ]
+      },
+      "hier_ps_M37_AXI": {
+        "interface_ports": [
+          "amdc_dac_0/S00_AXI",
+          "hier_ps/M05_AXI"
+        ]
+      },
+      "S00_AXI2_4": {
+        "interface_ports": [
+          "hier_gpio_2/S00_AXI2",
+          "hier_ps/M20_AXI"
         ]
       },
       "S00_AXI3_4": {
@@ -8950,76 +9247,10 @@
           "hier_ps/M23_AXI"
         ]
       },
-      "S00_AXI2_2": {
-        "interface_ports": [
-          "hier_gpio_0/S00_AXI2",
-          "hier_ps/M10_AXI"
-        ]
-      },
-      "S00_AXI3_1": {
-        "interface_ports": [
-          "hier_gpio_0/S00_AXI3",
-          "hier_ps/M12_AXI"
-        ]
-      },
-      "S00_AXI_1": {
-        "interface_ports": [
-          "hier_powerstack/S00_AXI",
-          "hier_ps/M06_AXI"
-        ]
-      },
-      "S00_AXI1_4": {
-        "interface_ports": [
-          "hier_gpio_2/S00_AXI1",
-          "hier_ps/M21_AXI"
-        ]
-      },
-      "S00_AXI2_3": {
-        "interface_ports": [
-          "hier_gpio_1/S00_AXI2",
-          "hier_ps/M15_AXI"
-        ]
-      },
-      "S00_AXI3_3": {
-        "interface_ports": [
-          "hier_gpio_2/S00_AXI3",
-          "hier_ps/M22_AXI"
-        ]
-      },
       "S00_AXI2_5": {
         "interface_ports": [
           "hier_gpio_3/S00_AXI2",
           "hier_ps/M25_AXI"
-        ]
-      },
-      "S00_AXI_4": {
-        "interface_ports": [
-          "hier_gpio_2/S00_AXI",
-          "hier_ps/M19_AXI"
-        ]
-      },
-      "processing_system7_0_FIXED_IO": {
-        "interface_ports": [
-          "FIXED_IO",
-          "hier_ps/FIXED_IO"
-        ]
-      },
-      "S00_AXI2_4": {
-        "interface_ports": [
-          "hier_gpio_2/S00_AXI2",
-          "hier_ps/M20_AXI"
-        ]
-      },
-      "S00_AXI4_2": {
-        "interface_ports": [
-          "hier_gpio_1/S00_AXI4",
-          "hier_ps/M18_AXI"
-        ]
-      },
-      "hier_ps_M35_AXI": {
-        "interface_ports": [
-          "amdc_leds_0/S00_AXI",
-          "hier_ps/M03_AXI"
         ]
       },
       "S00_AXI1_1": {
@@ -9028,28 +9259,16 @@
           "hier_ps/M07_AXI"
         ]
       },
-      "hier_ps_M37_AXI": {
-        "interface_ports": [
-          "amdc_dac_0/S00_AXI",
-          "hier_ps/M05_AXI"
-        ]
-      },
-      "S00_AXI1_2": {
-        "interface_ports": [
-          "hier_gpio_0/S00_AXI1",
-          "hier_ps/M11_AXI"
-        ]
-      },
       "hier_ps_M31_AXI": {
         "interface_ports": [
           "hier_ps/M31_AXI",
           "hier_gpio_2/S00_AXI5"
         ]
       },
-      "hier_ps_M33_AXI": {
+      "S00_AXI_1": {
         "interface_ports": [
-          "hier_timers/S_AXI1",
-          "hier_ps/M01_AXI"
+          "hier_powerstack/S00_AXI",
+          "hier_ps/M06_AXI"
         ]
       }
     },
@@ -9057,6 +9276,7 @@
       "processing_system7_0_FCLK_CLK0": {
         "ports": [
           "hier_ps/FCLK_CLK0",
+          "amdc_encoder_0/s00_axi_aclk",
           "amdc_leds_0/s00_axi_aclk",
           "amdc_adc_0/s00_axi_aclk",
           "amdc_dac_0/s00_axi_aclk",
@@ -9065,13 +9285,13 @@
           "hier_timers/s_axi_aclk",
           "hier_gpio_1/s00_axi_aclk",
           "hier_gpio_2/s00_axi_aclk",
-          "hier_gpio_3/s00_axi_aclk",
-          "amdc_encoder_0/s00_axi_aclk"
+          "hier_gpio_3/s00_axi_aclk"
         ]
       },
       "rst_ps7_0_100M_peripheral_aresetn": {
         "ports": [
           "hier_ps/S00_ARESETN",
+          "amdc_encoder_0/s00_axi_aresetn",
           "amdc_leds_0/s00_axi_aresetn",
           "amdc_adc_0/s00_axi_aresetn",
           "amdc_dac_0/s00_axi_aresetn",
@@ -9080,8 +9300,7 @@
           "hier_timers/s_axi_aresetn",
           "hier_gpio_1/s00_axi_aresetn",
           "hier_gpio_2/s00_axi_aresetn",
-          "hier_gpio_3/s00_axi_aresetn",
-          "amdc_encoder_0/s00_axi_aresetn"
+          "hier_gpio_3/s00_axi_aresetn"
         ]
       },
       "adc1_sdo_1": {

--- a/ip_repo/amdc_encoder_1.0/component.xml
+++ b/ip_repo/amdc_encoder_1.0/component.xml
@@ -199,7 +199,7 @@
       <spirit:parameters>
         <spirit:parameter>
           <spirit:name>POLARITY</spirit:name>
-          <spirit:value spirit:id="BUSIFPARAM_VALUE.S00_AXI_RST.POLARITY">ACTIVE_LOW</spirit:value>
+          <spirit:value spirit:id="BUSIFPARAM_VALUE.S00_AXI_RST.POLARITY" spirit:choiceRef="choice_list_9d8b0d81">ACTIVE_LOW</spirit:value>
         </spirit:parameter>
       </spirit:parameters>
     </spirit:busInterface>
@@ -310,7 +310,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>dfc5aa3a</spirit:value>
+            <spirit:value>5ae65769</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -326,7 +326,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>dfc5aa3a</spirit:value>
+            <spirit:value>5ae65769</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -454,6 +454,32 @@
       </spirit:port>
       <spirit:port>
         <spirit:name>alarm_D</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_verilogsynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_verilogbehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>pwm_carrier_low</spirit:name>
+        <spirit:wire>
+          <spirit:direction>in</spirit:direction>
+          <spirit:wireTypeDefs>
+            <spirit:wireTypeDef>
+              <spirit:typeName>wire</spirit:typeName>
+              <spirit:viewNameRef>xilinx_verilogsynthesis</spirit:viewNameRef>
+              <spirit:viewNameRef>xilinx_verilogbehavioralsimulation</spirit:viewNameRef>
+            </spirit:wireTypeDef>
+          </spirit:wireTypeDefs>
+        </spirit:wire>
+      </spirit:port>
+      <spirit:port>
+        <spirit:name>pwm_carrier_high</spirit:name>
         <spirit:wire>
           <spirit:direction>in</spirit:direction>
           <spirit:wireTypeDefs>
@@ -820,7 +846,7 @@
       <spirit:file>
         <spirit:name>hdl/amdc_encoder_v1_0.v</spirit:name>
         <spirit:fileType>verilogSource</spirit:fileType>
-        <spirit:userFileType>CHECKSUM_a7bde5ea</spirit:userFileType>
+        <spirit:userFileType>CHECKSUM_3c699582</spirit:userFileType>
       </spirit:file>
     </spirit:fileSet>
     <spirit:fileSet>
@@ -875,7 +901,7 @@
       <spirit:file>
         <spirit:name>xgui/amdc_encoder_v1_0.tcl</spirit:name>
         <spirit:fileType>tclSource</spirit:fileType>
-        <spirit:userFileType>CHECKSUM_fd592ead</spirit:userFileType>
+        <spirit:userFileType>CHECKSUM_dda4df14</spirit:userFileType>
         <spirit:userFileType>XGUI_VERSION_2</spirit:userFileType>
       </spirit:file>
     </spirit:fileSet>
@@ -953,20 +979,57 @@
         <xilinx:taxonomy>AXI_Peripheral</xilinx:taxonomy>
       </xilinx:taxonomies>
       <xilinx:displayName>amdc_encoder_v1.0</xilinx:displayName>
-      <xilinx:coreRevision>5</xilinx:coreRevision>
-      <xilinx:coreCreationDateTime>2019-05-09T18:37:10Z</xilinx:coreCreationDateTime>
+      <xilinx:coreRevision>10</xilinx:coreRevision>
+      <xilinx:coreCreationDateTime>2023-07-17T20:42:57Z</xilinx:coreCreationDateTime>
       <xilinx:tags>
         <xilinx:tag xilinx:name="wisc.edu:user:amdc_encoder:1.0_ARCHIVE_LOCATION">c:/Users/npetersen2/Documents/GitHub/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@102ba367_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@11d09b1b_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@7d675c3c_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@62627f48_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@64324494_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@21853f7d_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@e128792_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@ed3a4a1_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@63fb740c_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@329af6d7_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@5f8322b4_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@48c5f0fa_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@53f32de7_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@3151011f_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@2c64ce9_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@40b09ada_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@31c1c9b_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@2faa0f8f_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@6b7199e_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@243fb00b_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@7559c7c5_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@1f8edac8_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@329d294f_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@70e1bde3_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@4fc13a9d_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@6862a2d_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@2cc9472a_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@6fb93590_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@7ba577a7_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@1d83f1cc_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@36508732_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@3144d291_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@7a022c52_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@1b956b6c_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@59066836_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@79db48f6_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@31d05afc_ARCHIVE_LOCATION">c:/Users/atolson3/Documents/AMDC/AMDC-Firmware/ip_repo/amdc_encoder_1.0</xilinx:tag>
       </xilinx:tags>
     </xilinx:coreExtensions>
     <xilinx:packagingInfo>
-      <xilinx:xilinxVersion>2017.2</xilinx:xilinxVersion>
-      <xilinx:checksum xilinx:scope="busInterfaces" xilinx:value="2ed2abfa"/>
-      <xilinx:checksum xilinx:scope="memoryMaps" xilinx:value="493665f4"/>
-      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="ac5e057a"/>
-      <xilinx:checksum xilinx:scope="ports" xilinx:value="fc1de860"/>
-      <xilinx:checksum xilinx:scope="hdlParameters" xilinx:value="4429bb0c"/>
-      <xilinx:checksum xilinx:scope="parameters" xilinx:value="1e8de4a4"/>
+      <xilinx:xilinxVersion>2019.1</xilinx:xilinxVersion>
+      <xilinx:checksum xilinx:scope="busInterfaces" xilinx:value="074dfd38"/>
+      <xilinx:checksum xilinx:scope="memoryMaps" xilinx:value="ed1368d5"/>
+      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="d905d849"/>
+      <xilinx:checksum xilinx:scope="ports" xilinx:value="0ee3fdb0"/>
+      <xilinx:checksum xilinx:scope="hdlParameters" xilinx:value="6992ea72"/>
+      <xilinx:checksum xilinx:scope="parameters" xilinx:value="7a98626d"/>
     </xilinx:packagingInfo>
   </spirit:vendorExtensions>
 </spirit:component>

--- a/ip_repo/amdc_encoder_1.0/hdl/amdc_encoder_v1_0.v
+++ b/ip_repo/amdc_encoder_1.0/hdl/amdc_encoder_v1_0.v
@@ -22,6 +22,8 @@
         input wire alarm_B,
         input wire alarm_Z,
         input wire alarm_D,
+        input wire pwm_carrier_low,
+        input wire pwm_carrier_high,
 		// User ports ends
 		// Do not modify the ports beyond this line
 
@@ -77,7 +79,9 @@
 		.S_AXI_RREADY(s00_axi_rready),
 		.A(A),
 		.B(B),
-		.Z(Z)
+		.Z(Z),
+		.pwm_carrier_high(pwm_carrier_high),
+		.pwm_carrier_low(pwm_carrier_low)
 	);
 
 	// Add user logic here

--- a/ip_repo/amdc_encoder_1.0/hdl/amdc_encoder_v1_0_S00_AXI.v
+++ b/ip_repo/amdc_encoder_1.0/hdl/amdc_encoder_v1_0_S00_AXI.v
@@ -18,6 +18,8 @@
         input wire A,
         input wire B,
         input wire Z,
+		input wire pwm_carrier_high,
+		input wire pwm_carrier_low,
 		// User ports ends
 		// Do not modify the ports beyond this line
 
@@ -85,6 +87,8 @@
 
 	wire [31:0] counter;
 	wire [31:0] position;
+	wire [31:0] steps_synced;
+	wire [31:0] position_synced;
 	
 	// AXI4LITE signals
 	reg [C_S_AXI_ADDR_WIDTH-1 : 0] 	axi_awaddr;
@@ -377,8 +381,8 @@
 	      case ( axi_araddr[ADDR_LSB+OPT_MEM_ADDR_BITS:ADDR_LSB] )
 	        2'h0   : reg_data_out <= counter;
 	        2'h1   : reg_data_out <= position;
-	        2'h2   : reg_data_out <= slv_reg2;
-	        2'h3   : reg_data_out <= slv_reg3;
+	        2'h2   : reg_data_out <= steps_synced;
+	        2'h3   : reg_data_out <= position_synced;
 	        default : reg_data_out <= 0;
 	      endcase
 	end
@@ -411,7 +415,11 @@
 		.Z(Z),
         .counter(counter),
 		.position(position),
-		.pulses_per_rev_bits(slv_reg2)
+		.pulses_per_rev(slv_reg2),
+		.pwm_carrier_high(pwm_carrier_high),
+		.pwm_carrier_low(pwm_carrier_low),
+		.position_synced(position_synced),
+		.steps_synced(steps_synced)
     );
 
 

--- a/ip_repo/amdc_encoder_1.0/src/encoder_tb.sv
+++ b/ip_repo/amdc_encoder_1.0/src/encoder_tb.sv
@@ -1,0 +1,190 @@
+`timescale 1ns / 1ps
+
+`define PULSES_PER_REVOLUTION_BITS (32'd12)
+
+module encoder_tb();
+
+logic clk, rst_n;
+logic A, B, Z;
+logic [31:0] pulses_per_rev_bits;
+logic [7:0] divider;
+logic [15:0] carrier_max;
+
+logic pwm_carrier_low, pwm_carrier_high;
+logic [31:0] counter;
+logic [31:0] position;
+logic [31:0] steps_synced;
+logic [31:0] position_synced;
+logic [15:0] carrier;
+
+logic [31:0] value_steps, value_pos;
+
+triangle_carrier triangleWaves(
+	.clk(clk),
+	.rst_n(rst_n),
+	.divider(divider),
+	.carrier_max(carrier_max),
+	.carrier(carrier),
+	.carrier_high(pwm_carrier_high),
+	.carrier_low(pwm_carrier_low)
+);
+
+encoder iDUT(
+	.clk(clk),
+	.rst_n(rst_n),
+	.A(A),
+	.B(B),
+	.Z(Z),
+	.counter(counter),
+	.pwm_carrier_high(pwm_carrier_high),
+	.pwm_carrier_low(pwm_carrier_low),
+	.position(position),
+	.pulses_per_rev(`PULSES_PER_REVOLUTION_BITS),
+	.steps_synced(steps_synced),
+	.position_synced(position_synced)
+);
+
+// task for testing, call from initial block?
+task test_updates;
+	input int dir;
+	input int num_revs;
+	input int cycles;
+	input int speed;
+	
+	begin
+		// Simulate revs
+		repeat (num_revs) begin
+			Z = 1;
+			if (dir) A = 1; else B = 1;
+			repeat (speed) @(posedge clk);
+			Z = 0;
+			if (dir) B = 1; else A = 1;
+			repeat (speed) @(posedge clk);
+			if (dir) A = 0; else B = 0;
+			repeat (speed) @(posedge clk);
+			if (dir) B = 0; else A = 0;
+			repeat (speed) @(posedge clk);
+
+
+			// Simulate (`cycles_per_rev` - 1) more cycles (or 4x pulses)
+			repeat (cycles - 1) begin
+				if (dir) A = 1; else B = 1;
+				repeat (speed) @(posedge clk);
+				if (dir) B = 1; else A = 1;
+				repeat (speed) @(posedge clk);
+				if (dir) A = 0; else B = 0;
+				repeat (speed) @(posedge clk);
+				if (dir) B = 0; else A = 0;
+				repeat (speed) @(posedge clk);
+			
+			end
+		end
+	end
+endtask
+
+initial begin
+	clk = 1'b0;
+	rst_n = 1'b1;
+	
+	A = 0;
+	B = 0;
+	Z = 0;
+	divider = 8'b0;
+	carrier_max = 16'd1000;
+	
+	@(posedge clk);
+	rst_n = 1'b0;
+	
+	@(posedge clk);
+	@(negedge clk);
+	rst_n = 1'b1;
+
+	// Simulate some amount of cycles before hitting
+	// Z pulse; the counter should hold 20 steps here
+	repeat (5) begin
+		A = 1;
+		repeat (5) @(posedge clk);
+		B = 1;
+		repeat (5) @(posedge clk);
+		A = 0;
+		repeat (5) @(posedge clk);
+		B = 0;
+		repeat (5) @(posedge clk);
+	end
+
+	test_updates(1, 1, (1 << `PULSES_PER_REVOLUTION_BITS) / 4, 5);	// 2,400,000 RPM
+	$display("2,400,000 RPM | Synced Steps: %d | Synced Position: %d | Inst. Steps: %d | Inst. Position: %d",steps_synced, position_synced, counter, position);
+	test_updates(0, 1, (1 << `PULSES_PER_REVOLUTION_BITS) / 4, 60);	// 200,000 RPM
+	$display("200,000 RPM   | Synced Steps: %d | Synced Position: %d | Inst. Steps: %d | Inst. Position: %d",steps_synced, position_synced, counter, position);
+	test_updates(1, 1, (1 << `PULSES_PER_REVOLUTION_BITS) / 4, 120);	// 100,000 RPM
+	$display("100,000 RPM   | Synced Steps: %d | Synced Position: %d | Inst. Steps: %d | Inst. Position: %d",steps_synced, position_synced, counter, position);
+	test_updates(1, 1, (1 << `PULSES_PER_REVOLUTION_BITS) / 4, 240);	// 50,000 RPM
+	$display("50,000 RPM    | Synced Steps: %d | Synced Position: %d | Inst. Steps: %d | Inst. Position: %d",steps_synced, position_synced, counter, position);
+	test_updates(1, 1, (1 << `PULSES_PER_REVOLUTION_BITS) / 4, 1200);	// 10,000 RPM
+	$display("10,000 RPM    | Synced Steps: %d | Synced Position: %d | Inst. Steps: %d | Inst. Position: %d",steps_synced, position_synced, counter, position);
+	test_updates(1, 1, (1 << `PULSES_PER_REVOLUTION_BITS) / 4, 2400);	// 5,000 RPM
+	$display("5,000 RPM     | Synced Steps: %d | Synced Position: %d | Inst. Steps: %d | Inst. Position: %d",steps_synced, position_synced, counter, position);
+
+	$display("All tests passed!");
+	$stop();
+
+end
+
+// *********************************************************
+// Check that the synced values are unchanging between carrier 
+// high and low signal assertion
+// *********************************************************
+
+// Falling edge detector for carrier high signal
+logic fall_edge_high, carrier_high_ff;
+always_ff @(posedge clk, negedge rst_n) begin
+	if (!rst_n)
+		carrier_high_ff <= 1'b0;
+	else
+		carrier_high_ff <= pwm_carrier_high;
+end
+
+assign fall_edge_high = (~pwm_carrier_high) & carrier_high_ff;
+
+// Falling edge detector for carrier low signal
+logic fall_low_low, carrier_low_ff;
+always_ff @(posedge clk, negedge rst_n) begin
+	if (!rst_n)
+		carrier_low_ff <= 1'b0;
+	else
+		carrier_low_ff <= pwm_carrier_low;
+end
+
+assign fall_edge_low = (~pwm_carrier_low) & carrier_low_ff;
+
+// Check that values are held
+always_ff @(posedge clk) begin
+	if (fall_edge_high) begin
+		value_steps <= steps_synced;
+		value_pos <= position_synced;
+		if (pwm_carrier_low) begin
+			// Check that synced values are retained
+			if ((value_steps !== steps_synced) || (value_pos !== position_synced)) begin
+				$display("Updates not synced!");
+				$stop();
+			end
+		end
+	end else if (fall_edge_low) begin
+		value_steps <= steps_synced;
+		value_pos <= position_synced;
+		if (pwm_carrier_high) begin
+			// Check that synced values are retained
+			if ((value_steps !== steps_synced) || (value_pos !== position_synced)) begin
+				$display("Updates not synced!");
+				$stop();
+			end
+		end
+	end
+end
+
+
+always
+	#2.5 clk = ~clk; // 200 MHz clock with 5 ns period
+
+		
+endmodule

--- a/sdk/app_cpu1/common/drv/encoder.c
+++ b/sdk/app_cpu1/common/drv/encoder.c
@@ -15,14 +15,13 @@ void encoder_init(void)
 
 void encoder_set_pulses_per_rev_bits(uint32_t bits)
 {
-		printf("ENC:\tSetting pulses per rev bits = %ld...\n", bits);
-	encoder_set_pulses_per_rev(pow((uint32_t) 2), bits));
+    printf("ENC:\tSetting pulses per rev bits = %ld...\n", bits);
+	encoder_set_pulses_per_rev(1 << bits);
 }
 
 void encoder_set_pulses_per_rev(uint32_t pulses)
 {
 	printf("ENC:\tSetting pulses per rev = %ld...\n", pulses);
-	
 	
     Xil_Out32(ENCODER_BASE_ADDR + 2 * sizeof(uint32_t), pulses);
 }

--- a/sdk/app_cpu1/common/drv/encoder.c
+++ b/sdk/app_cpu1/common/drv/encoder.c
@@ -2,6 +2,7 @@
 #include "sys/defines.h"
 #include "sys/scheduler.h"
 #include "xil_io.h"
+#include <math.h>
 #include <stdio.h>
 
 #define ENCODER_BASE_ADDR (0x43C10000)
@@ -14,17 +15,34 @@ void encoder_init(void)
 
 void encoder_set_pulses_per_rev_bits(uint32_t bits)
 {
-    printf("ENC:\tSetting pulses per rev bits = %ld...\n", bits);
+		printf("ENC:\tSetting pulses per rev bits = %ld...\n", bits);
+	encoder_set_pulses_per_rev(pow((uint32_t) 2), bits));
+}
 
-    Xil_Out32(ENCODER_BASE_ADDR + 2 * sizeof(uint32_t), bits);
+void encoder_set_pulses_per_rev(uint32_t pulses)
+{
+	printf("ENC:\tSetting pulses per rev = %ld...\n", pulses);
+	
+	
+    Xil_Out32(ENCODER_BASE_ADDR + 2 * sizeof(uint32_t), pulses);
 }
 
 void encoder_get_steps(int32_t *steps)
+{
+    *steps = Xil_In32(ENCODER_BASE_ADDR + 2 * sizeof(uint32_t));
+}
+
+void encoder_get_steps_instantaneous(int32_t *steps)
 {
     *steps = Xil_In32(ENCODER_BASE_ADDR);
 }
 
 void encoder_get_position(uint32_t *position)
+{
+	*position = Xil_In32(ENCODER_BASE_ADDR + 3 * sizeof(uint32_t));
+}
+
+void encoder_get_pos_instantaneous(uint32_t *position)
 {
     *position = Xil_In32(ENCODER_BASE_ADDR + 1 * sizeof(uint32_t));
 }

--- a/sdk/app_cpu1/common/drv/encoder.c
+++ b/sdk/app_cpu1/common/drv/encoder.c
@@ -15,13 +15,13 @@ void encoder_init(void)
 void encoder_set_pulses_per_rev_bits(uint32_t bits)
 {
     printf("ENC:\tSetting pulses per rev bits = %ld...\n", bits);
-	encoder_set_pulses_per_rev(1 << bits);
+    encoder_set_pulses_per_rev(1 << bits);
 }
 
 void encoder_set_pulses_per_rev(uint32_t pulses)
 {
-	printf("ENC:\tSetting pulses per rev = %ld...\n", pulses);
-	
+    printf("ENC:\tSetting pulses per rev = %ld...\n", pulses);
+
     Xil_Out32(ENCODER_BASE_ADDR + 2 * sizeof(uint32_t), pulses);
 }
 
@@ -37,7 +37,7 @@ void encoder_get_steps_instantaneous(int32_t *steps)
 
 void encoder_get_position(uint32_t *position)
 {
-	*position = Xil_In32(ENCODER_BASE_ADDR + 3 * sizeof(uint32_t));
+    *position = Xil_In32(ENCODER_BASE_ADDR + 3 * sizeof(uint32_t));
 }
 
 void encoder_get_pos_instantaneous(uint32_t *position)

--- a/sdk/app_cpu1/common/drv/encoder.c
+++ b/sdk/app_cpu1/common/drv/encoder.c
@@ -39,7 +39,7 @@ void encoder_get_position(uint32_t *position)
     *position = Xil_In32(ENCODER_BASE_ADDR + 3 * sizeof(uint32_t));
 }
 
-void encoder_get_pos_instantaneous(uint32_t *position)
+void encoder_get_position_instantaneous(uint32_t *position)
 {
     *position = Xil_In32(ENCODER_BASE_ADDR + 1 * sizeof(uint32_t));
 }

--- a/sdk/app_cpu1/common/drv/encoder.c
+++ b/sdk/app_cpu1/common/drv/encoder.c
@@ -2,8 +2,7 @@
 #include "sys/defines.h"
 #include "sys/scheduler.h"
 #include "xil_io.h"
-#include <math.h>
-#include <stdio.h>
+
 #define ENCODER_BASE_ADDR (0x43C10000)
 
 void encoder_init(void)

--- a/sdk/app_cpu1/common/drv/encoder.c
+++ b/sdk/app_cpu1/common/drv/encoder.c
@@ -4,7 +4,6 @@
 #include "xil_io.h"
 #include <math.h>
 #include <stdio.h>
-
 #define ENCODER_BASE_ADDR (0x43C10000)
 
 void encoder_init(void)

--- a/sdk/app_cpu1/common/drv/encoder.h
+++ b/sdk/app_cpu1/common/drv/encoder.h
@@ -9,9 +9,11 @@
 void encoder_init(void);
 
 void encoder_set_pulses_per_rev_bits(uint32_t bits);
-
+void encoder_set_pulses_per_rev(uint32_t pulses);
 void encoder_get_steps(int32_t *steps);
+void encoder_get_steps_instantaneous(int32_t *steps);
 void encoder_get_position(uint32_t *position);
+void encoder_get_pos_instantaneous(uint32_t *position);
 
 void encoder_find_z(void);
 

--- a/sdk/app_cpu1/common/drv/encoder.h
+++ b/sdk/app_cpu1/common/drv/encoder.h
@@ -13,7 +13,7 @@ void encoder_set_pulses_per_rev(uint32_t pulses);
 void encoder_get_steps(int32_t *steps);
 void encoder_get_steps_instantaneous(int32_t *steps);
 void encoder_get_position(uint32_t *position);
-void encoder_get_pos_instantaneous(uint32_t *position);
+void encoder_get_position_instantaneous(uint32_t *position);
 
 void encoder_find_z(void);
 


### PR DESCRIPTION
This PR addresses issues #313 and #16 with the primary purpose being to ensure that the register updates from the encoder are synchronous with the control code. This PR also incorporates the stale PR #263.

# Encoder Modifications

The two register updates that come from the encoder are steps, which are held in the `counter` register, and position, which is held in the `position` register. Two new registers, `steps_synced` and `position_synced` were added to hold the values of the steps and position from the current state of the encoder relative to AMDC-Firmware timing.

In order to synchronize the PWM Carrier signals with the encoder interface, the first thing to do was pass the internal `pwm_carrier_high` and `pwm_carrier_low` signals into the encoder IP core and connect those signals in throughout the modules. Then, the [encoder interface was updated](https://github.com/Severson-Group/AMDC-Firmware/pull/317/files#diff-c71ee0d834143055928a56fbda1328b02fd1f318c569ac34f1a52ddb8e150a9dR238-R259) to copy the instantaneous register updates to newly created synced registers when the PWM carrier high or low signals are true, based on the points from the triangle carrier wave:

```Verilog
else if (pwm_carrier_low || pwm_carrier_high) begin
    steps_synced <= counter;
    position_synced <= position;
 end
```

# Driver Modifications

In the AXI Verilog file, the [read registers](https://github.com/Severson-Group/AMDC-Firmware/blob/401b48b845dfd9f0903f5865db7e142e2fd9bcd2/ip_repo/amdc_encoder_1.0/hdl/amdc_encoder_v1_0_S00_AXI.v#L382-L385) were updated to add in the synced values from the encoder interface:
```Verilog
  2'h2   : reg_data_out <= steps_synced;
  2'h3   : reg_data_out <= position_synced;
```
Thus, the encoder driver was [updated](https://github.com/Severson-Group/AMDC-Firmware/blob/401b48b845dfd9f0903f5865db7e142e2fd9bcd2/sdk/app_cpu1/common/drv/encoder.c#L30-L48) to make the defaults for retrieving the steps and position now get the synced values. The old functions, which were previously the default, were updated to a different name with "_instantaneous" added, as that will now need to be called in order to get the immediate value from the registers `counter` and `position`.

### Code Modification Example

*The new default to get the correctly synchronized value of the steps; the offset is set to 2, which, as seen above, reads the value from `steps_synced`:*
```C
void encoder_get_steps(int32_t *steps)
{
    *steps = Xil_In32(ENCODER_BASE_ADDR + 2 * sizeof(uint32_t));
}
```

*The old default which now gets the immediate value of the steps; the offset is set to 0, which reads the value from `counter`:*
```C
void encoder_get_steps_instantaneous(int32_t *steps)
{
    *steps = Xil_In32(ENCODER_BASE_ADDR);
}
```

# Changes Made to Address Issue #16
These changes address the issue that the firmware only supports pulses per revolution that are a power of 2.

The new default created in the FPGA code changes the `pulses_per_rev_bits` signal to `pulses_per_rev` and does not shift the pulses when [assigning the `MAX_POS` signal](https://github.com/Severson-Group/AMDC-Firmware/pull/317/files#diff-c71ee0d834143055928a56fbda1328b02fd1f318c569ac34f1a52ddb8e150a9dR191-R192).

The encoder driver was also [modified](https://github.com/Severson-Group/AMDC-Firmware/pull/317/files#diff-ca46f5b2a567983b409847fd79f6dd89f8a6cb9ff7afd5870698304895311298R18-R25) to add a new function which changes the parameter to pulses versus bits:
```C
void encoder_set_pulses_per_rev(uint32_t pulses)
{
    printf("ENC:\tSetting pulses per rev = %ld...\n", pulses);
    Xil_Out32(ENCODER_BASE_ADDR + 2 * sizeof(uint32_t), pulses);
}
```
`encoder_set_pulses_per_rev_bits()` now calls the new function with an argument of 1 shifted left by the inputted amount of bits.

# Testing
A [SystemVerilog test bench](https://github.com/Severson-Group/AMDC-Firmware/blob/a258cb079d59d57728e8334d39d2a875354313c1/ip_repo/amdc_encoder_1.0/src/encoder_tb.sv) was created to model the behavior of the encoder and test the results at different speeds. For this test, six different cases were used, varying the amount of clock cycles between the A and B pulses changing from 5 to 2400 (2.4 million RPM to 5,000 RPM). The direction was also changed. The task to simulate these revolutions took inputs of `direction`, number of `revolutions`, `cycles`, and `speed` (in clock cycles). In this test bench, the pulses per revolution was set to 12 (decimal), and this was connected to the newly changed input of `pulses_per_rev` in instantiation of the encoder peripheral.

This was the equation used to find the number of clocks to simulate based on an RPM value and a 5 ns clock period:
$clocks = {60 \over 1000*{RPM*5e-9}}$

Here is an example of when the encoder is simulated at 100,000 RPM:
![image](https://github.com/Severson-Group/AMDC-Firmware/assets/132917023/45cca4a5-287a-4ba4-bd30-7ed09c3b0296)

As can be seen, at the negative edge of the carrier high signal, the `steps_synced` and `position_synced` registers now hold the value from `counter` and `position` from the last clock cycle.

The test bench was [automated](https://github.com/Severson-Group/AMDC-Firmware/blob/a258cb079d59d57728e8334d39d2a875354313c1/ip_repo/amdc_encoder_1.0/src/encoder_tb.sv#L133-L183) to stop and produce an error message if the synced registers' values changed when between assertion of either the carrier high or low signals, therefore indicating that the register updates are no longer synchronized. Falling edge detectors were added to find both the negative edge of the carrier low and high signals; a flop was added to check that the synced values are held for both cases.

## Results
At lower speeds, it behaves similarly; the immediate `counter` and `position` registers do not change often between the `pwm_carrier_high` and `pwm_carrier_low` signals being asserted. Therefore, the synchronization issue is not as clearly seen with these arguments; if the speed is low enough, the immediate values will not change between carrier signals and would read the same value as the copied synced values for a large portion of the time. Here is an example of how this looks at 10,000 RPM:
![image](https://github.com/Severson-Group/AMDC-Firmware/assets/132917023/a6e0362e-e323-471b-b210-ab601b314b72)

However, at higher speeds, it is much clearer that synchronization works better. Both the `position` and `counter` registers update frequently between the high and low signals; however, the synced values hold the data that was stored at the previous carrier signal. Here is an example of this happening at 100,000 RPM:
![image](https://github.com/Severson-Group/AMDC-Firmware/assets/132917023/2592e45d-54b3-4f9b-83c0-a09f60746bd1)

A `$display()` statement was added after each call to the simulation task to show the difference in the synced versus immediate values. It can be seen that at very slow speeds, they are the same, but at higher speeds, they have a greater difference, which further proves the functionality and impact of this synchronization update to the encoder.

![image](https://github.com/Severson-Group/AMDC-Firmware/assets/132917023/b5e8707b-a128-4a32-8cba-d0f5399ec2c4)

The synced registers retain the value from when the high or low signals are asserted, and only change at the next negative clock edge of the next signal. This improves the functionality at higher speeds. In all, the value of the steps and position are now synchronized with the AMDC firmware timing, instead of being relative to the encoder.