### PR TITLE
Fix pcbtest application for REV E/F hardware target

### DIFF
--- a/sdk/app_cpu1/common/usr/pcbtest/app_pcbtest.c
+++ b/sdk/app_cpu1/common/usr/pcbtest/app_pcbtest.c
@@ -3,10 +3,16 @@
 #include "usr/pcbtest/app_pcbtest.h"
 #include "drv/pwm.h"
 #include "usr/pcbtest/cmd/cmd_test.h"
+#include "usr/user_config.h"
 
 void app_pcbtest_init(void)
 {
     cmd_test_register();
+
+#if (USER_CONFIG_HARDWARE_TARGET == AMDC_REV_E) || (USER_CONFIG_HARDWARE_TARGET == AMDC_REV_F)
+    // Enable hardware output for PWM signals
+    pwm_enable_hw(true);
+#endif
 }
 
 #endif // APP_PCBTEST


### PR DESCRIPTION
Resolves: #369

@DivyaMendpara and I tested this on the new AMDC REV F hardware---it works as expected and says the hardware passes the test.