### PR TITLE
update new mode to post-sensor mode

### DIFF
--- a/sdk/app_cpu1/common/drv/timing_manager.c
+++ b/sdk/app_cpu1/common/drv/timing_manager.c
@@ -172,10 +172,10 @@ uint32_t timing_manager_get_trigger_count(void)
 /*
  * Specify the interrupt source of the scheduler ISR:
  *
- * Mode 0 uses the timing manager's 'trigger' signal, i.e. the control
+ * legacy mode - uses the timing manager's 'trigger' signal, i.e. the control
  * frequency is based on the PWM carrier frequency and the user-specified PWM sub-ratio.
  *
- * Mode 1 uses the timing manager's 'all_done' signal, calling the scheduler
+ * post-sensor mode - uses the timing manager's 'all_done' signal, calling the scheduler
  * when all the sensors are done with acquisition. When no sensors are enabled,
  * the scheduler is called as in mode 0 (based on the trigger). This mode
  * supports reporting of the timing for each sensor

--- a/sdk/app_cpu1/common/drv/timing_manager.c
+++ b/sdk/app_cpu1/common/drv/timing_manager.c
@@ -172,10 +172,10 @@ uint32_t timing_manager_get_trigger_count(void)
 /*
  * Specify the interrupt source of the scheduler ISR:
  *
- * legacy mode - uses the timing manager's 'trigger' signal, i.e. the control
+ * Mode 0: legacy mode - uses the timing manager's 'trigger' signal, i.e. the control
  * frequency is based on the PWM carrier frequency and the user-specified PWM sub-ratio.
  *
- * post-sensor mode - uses the timing manager's 'all_done' signal, calling the scheduler
+ * Mode 1: post-sensor mode - uses the timing manager's 'all_done' signal, calling the scheduler
  * when all the sensors are done with acquisition. When no sensors are enabled,
  * the scheduler is called as in mode 0 (based on the trigger). This mode
  * supports reporting of the timing for each sensor

--- a/sdk/app_cpu1/user/usr/user_config.h
+++ b/sdk/app_cpu1/user/usr/user_config.h
@@ -12,7 +12,7 @@
 // Specify the source of the scheduler ISR
 // Mode 0: legacy mode - scheduler is triggered based on the PWM carrier events and ratio
 //         of carrier frequency to desired control frequency
-// Mode 1: post-sensor - scheduler is triggered when all the enabled sensors are done
+// Mode 1: post-sensor mode - scheduler is triggered when all the enabled sensors are done
 //         acquiring their data
 #define USER_CONFIG_ISR_SOURCE (0)
 

--- a/sdk/app_cpu1/user/usr/user_config.h
+++ b/sdk/app_cpu1/user/usr/user_config.h
@@ -12,7 +12,7 @@
 // Specify the source of the scheduler ISR
 // Mode 0: legacy mode - scheduler is triggered based on the PWM carrier events and ratio
 //         of carrier frequency to desired control frequency
-// Mode 1: new mode - scheduler is triggered when all the enabled sensors are done
+// Mode 1: post-sensor - scheduler is triggered when all the enabled sensors are done
 //         acquiring their data
 #define USER_CONFIG_ISR_SOURCE (0)
 


### PR DESCRIPTION
This PR closes #425 

This changes a single line in user_config.h to refer to the timing manager's "new mode" to "post-sensor mode" instead.